### PR TITLE
[build] Add custom scheme name for SPI manifest

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,3 +2,4 @@ version: 1
 builder:
   configs:
     - documentation_targets: [StytchCore]
+      scheme: StytchCore


### PR DESCRIPTION
It is my understanding that this custom scheme should fix [this issue](https://swiftpackageindex.com/builds/005703F8-F4FB-4FE4-AFF8-FDF54E3622FC), per [this blog post](https://blog.swiftpackageindex.com/posts/the-swift-package-index-metadata-file-first-steps/)