### PR TITLE
[build] Update min deployment target to iOS 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "Stytch",
-    platforms: [.iOS("11.3"), .macOS(.v10_13), .tvOS(.v11), .watchOS(.v4)],
+    platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
     products: [
         .library(name: "StytchCore", targets: ["StytchCore"]),
     ],

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ If you are completely new to Stytch, prior to using the SDK you will first need 
 ## Requirements
 
 The Stytch Swift SDK is compatible with apps targeting the following Apple platforms:
-- iOS 11.3+
-- macOS 10.13+
-- tvOS 11+
+- iOS 13+
+- macOS 10.15+
+- tvOS 13+
 
 ## Installation
 

--- a/Resources/Sourcery/Templates/AsyncVariants.stencil
+++ b/Resources/Sourcery/Templates/AsyncVariants.stencil
@@ -24,7 +24,6 @@ import Foundation
 #if canImport(Combine)
 import Combine
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension {{ type.name }} {
     {{ methodDocs }}
     {{ methodKeywords }} {{ methodDeclaration }} -> AnyPublisher<{{ returnType }}, Error> {
@@ -41,15 +40,8 @@ public extension {{ type.name }} {
 // MARK: - {{ methodName }} Async/Await
 #if compiler(>=5.5) && canImport(_Concurrency)
 public extension {{ type.name }} {
-    #if compiler(>=5.5.2)
     {{ methodDocs }}
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     {{ asyncFunction }}
-    #else
-    {{ methodDocs }}
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    {{ asyncFunction }}
-    #endif
 }
 #endif
 // sourcery:end

--- a/Sources/StytchCore/Generated/StytchClient+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient+AsyncVariants.generated.swift
@@ -6,7 +6,6 @@ import Foundation
 #if canImport(Combine)
 import Combine
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension StytchClient {
     /// This function is provided as a simple convenience handler to be used in your AppDelegate or
     /// SwiftUI App file upon receiving a deeplink URL, e.g. `.onOpenURL {}`.
@@ -30,7 +29,6 @@ public extension StytchClient {
 // MARK: - handle Async/Await
 #if compiler(>=5.5) && canImport(_Concurrency)
 public extension StytchClient {
-    #if compiler(>=5.5.2)
     /// This function is provided as a simple convenience handler to be used in your AppDelegate or
     /// SwiftUI App file upon receiving a deeplink URL, e.g. `.onOpenURL {}`.
     /// If Stytch is able to handle the URL and log the user in, an ``AuthenticateResponse`` will be returned to you asynchronously, with a `sessionDuration` of
@@ -39,27 +37,10 @@ public extension StytchClient {
     ///    - url: A `URL` passed to your application as a deeplink.
     ///    - sessionDuration: The desired session duration in ``Minutes``. Defaults to 30.
     ///  - Returns: A ``DeeplinkHandledStatus`` will be returned asynchronously.
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     static func handle(url: URL, sessionDuration: Minutes = 30) async throws -> DeeplinkHandledStatus {
         try await withCheckedThrowingContinuation { continuation in
             handle(url: url, sessionDuration: sessionDuration, completion: continuation.resume)
         }
     }
-    #else
-    /// This function is provided as a simple convenience handler to be used in your AppDelegate or
-    /// SwiftUI App file upon receiving a deeplink URL, e.g. `.onOpenURL {}`.
-    /// If Stytch is able to handle the URL and log the user in, an ``AuthenticateResponse`` will be returned to you asynchronously, with a `sessionDuration` of
-    /// the length requested here.
-    ///  - Parameters:
-    ///    - url: A `URL` passed to your application as a deeplink.
-    ///    - sessionDuration: The desired session duration in ``Minutes``. Defaults to 30.
-    ///  - Returns: A ``DeeplinkHandledStatus`` will be returned asynchronously.
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    static func handle(url: URL, sessionDuration: Minutes = 30) async throws -> DeeplinkHandledStatus {
-        try await withCheckedThrowingContinuation { continuation in
-            handle(url: url, sessionDuration: sessionDuration, completion: continuation.resume)
-        }
-    }
-    #endif
 }
 #endif

--- a/Sources/StytchCore/Generated/StytchClient.MagicLinks+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.MagicLinks+AsyncVariants.generated.swift
@@ -6,7 +6,6 @@ import Foundation
 #if canImport(Combine)
 import Combine
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension StytchClient.MagicLinks {
     /// Wraps the magic link [authenticate](https://stytch.com/docs/api/authenticate-magic-link) API endpoint which validates the magic link token passed in. If this method succeeds, the user will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
     func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<AuthenticateResponse, Error> {
@@ -23,22 +22,11 @@ public extension StytchClient.MagicLinks {
 // MARK: - authenticate Async/Await
 #if compiler(>=5.5) && canImport(_Concurrency)
 public extension StytchClient.MagicLinks {
-    #if compiler(>=5.5.2)
     /// Wraps the magic link [authenticate](https://stytch.com/docs/api/authenticate-magic-link) API endpoint which validates the magic link token passed in. If this method succeeds, the user will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
         try await withCheckedThrowingContinuation { continuation in
             authenticate(parameters: parameters, completion: continuation.resume)
         }
     }
-    #else
-    /// Wraps the magic link [authenticate](https://stytch.com/docs/api/authenticate-magic-link) API endpoint which validates the magic link token passed in. If this method succeeds, the user will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
-        try await withCheckedThrowingContinuation { continuation in
-            authenticate(parameters: parameters, completion: continuation.resume)
-        }
-    }
-    #endif
 }
 #endif

--- a/Sources/StytchCore/Generated/StytchClient.MagicLinks.Email+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.MagicLinks.Email+AsyncVariants.generated.swift
@@ -6,7 +6,6 @@ import Foundation
 #if canImport(Combine)
 import Combine
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension StytchClient.MagicLinks.Email {
     /// Wraps Stytch's email magic link [login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-email) endpoint. Requests an email magic link for a user to log in or create an account depending on the presence and/or status current account.
     func loginOrCreate(parameters: Parameters) -> AnyPublisher<BasicResponse, Error> {
@@ -23,22 +22,11 @@ public extension StytchClient.MagicLinks.Email {
 // MARK: - loginOrCreate Async/Await
 #if compiler(>=5.5) && canImport(_Concurrency)
 public extension StytchClient.MagicLinks.Email {
-    #if compiler(>=5.5.2)
     /// Wraps Stytch's email magic link [login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-email) endpoint. Requests an email magic link for a user to log in or create an account depending on the presence and/or status current account.
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func loginOrCreate(parameters: Parameters) async throws -> BasicResponse {
         try await withCheckedThrowingContinuation { continuation in
             loginOrCreate(parameters: parameters, completion: continuation.resume)
         }
     }
-    #else
-    /// Wraps Stytch's email magic link [login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-email) endpoint. Requests an email magic link for a user to log in or create an account depending on the presence and/or status current account.
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func loginOrCreate(parameters: Parameters) async throws -> BasicResponse {
-        try await withCheckedThrowingContinuation { continuation in
-            loginOrCreate(parameters: parameters, completion: continuation.resume)
-        }
-    }
-    #endif
 }
 #endif

--- a/Sources/StytchCore/Generated/StytchClient.OneTimePasscodes+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.OneTimePasscodes+AsyncVariants.generated.swift
@@ -6,7 +6,6 @@ import Foundation
 #if canImport(Combine)
 import Combine
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension StytchClient.OneTimePasscodes {
     /// Wraps Stytch's OTP [sms/login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-sms), [whatsapp/login_or_create](https://stytch.com/docs/api/whatsapp-login-or-create), and [email/login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-email-otp) endpoints. Requests a one-time passcode for a user to log in or create an account depending on the presence and/or status current account.
     func loginOrCreate(parameters: LoginOrCreateParameters) -> AnyPublisher<LoginOrCreateResponse, Error> {
@@ -23,23 +22,12 @@ public extension StytchClient.OneTimePasscodes {
 // MARK: - loginOrCreate Async/Await
 #if compiler(>=5.5) && canImport(_Concurrency)
 public extension StytchClient.OneTimePasscodes {
-    #if compiler(>=5.5.2)
     /// Wraps Stytch's OTP [sms/login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-sms), [whatsapp/login_or_create](https://stytch.com/docs/api/whatsapp-login-or-create), and [email/login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-email-otp) endpoints. Requests a one-time passcode for a user to log in or create an account depending on the presence and/or status current account.
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func loginOrCreate(parameters: LoginOrCreateParameters) async throws -> LoginOrCreateResponse {
         try await withCheckedThrowingContinuation { continuation in
             loginOrCreate(parameters: parameters, completion: continuation.resume)
         }
     }
-    #else
-    /// Wraps Stytch's OTP [sms/login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-sms), [whatsapp/login_or_create](https://stytch.com/docs/api/whatsapp-login-or-create), and [email/login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-email-otp) endpoints. Requests a one-time passcode for a user to log in or create an account depending on the presence and/or status current account.
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func loginOrCreate(parameters: LoginOrCreateParameters) async throws -> LoginOrCreateResponse {
-        try await withCheckedThrowingContinuation { continuation in
-            loginOrCreate(parameters: parameters, completion: continuation.resume)
-        }
-    }
-    #endif
 }
 #endif
 
@@ -49,7 +37,6 @@ import Foundation
 #if canImport(Combine)
 import Combine
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension StytchClient.OneTimePasscodes {
     /// Wraps the OTP [authenticate](https://stytch.com/docs/api/authenticate-otp) API endpoint which validates the one-time code passed in. If this method succeeds, the user will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
     func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<AuthenticateResponse, Error> {
@@ -66,22 +53,11 @@ public extension StytchClient.OneTimePasscodes {
 // MARK: - authenticate Async/Await
 #if compiler(>=5.5) && canImport(_Concurrency)
 public extension StytchClient.OneTimePasscodes {
-    #if compiler(>=5.5.2)
     /// Wraps the OTP [authenticate](https://stytch.com/docs/api/authenticate-otp) API endpoint which validates the one-time code passed in. If this method succeeds, the user will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
         try await withCheckedThrowingContinuation { continuation in
             authenticate(parameters: parameters, completion: continuation.resume)
         }
     }
-    #else
-    /// Wraps the OTP [authenticate](https://stytch.com/docs/api/authenticate-otp) API endpoint which validates the one-time code passed in. If this method succeeds, the user will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
-        try await withCheckedThrowingContinuation { continuation in
-            authenticate(parameters: parameters, completion: continuation.resume)
-        }
-    }
-    #endif
 }
 #endif

--- a/Sources/StytchCore/Generated/StytchClient.Sessions+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.Sessions+AsyncVariants.generated.swift
@@ -6,7 +6,6 @@ import Foundation
 #if canImport(Combine)
 import Combine
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension StytchClient.Sessions {
     /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
     func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<SessionsAuthenticateResponse, Error> {
@@ -23,23 +22,12 @@ public extension StytchClient.Sessions {
 // MARK: - authenticate Async/Await
 #if compiler(>=5.5) && canImport(_Concurrency)
 public extension StytchClient.Sessions {
-    #if compiler(>=5.5.2)
     /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func authenticate(parameters: AuthenticateParameters) async throws -> SessionsAuthenticateResponse {
         try await withCheckedThrowingContinuation { continuation in
             authenticate(parameters: parameters, completion: continuation.resume)
         }
     }
-    #else
-    /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func authenticate(parameters: AuthenticateParameters) async throws -> SessionsAuthenticateResponse {
-        try await withCheckedThrowingContinuation { continuation in
-            authenticate(parameters: parameters, completion: continuation.resume)
-        }
-    }
-    #endif
 }
 #endif
 
@@ -49,7 +37,6 @@ import Foundation
 #if canImport(Combine)
 import Combine
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension StytchClient.Sessions {
     /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
     func revoke() -> AnyPublisher<SessionsRevokeResponse, Error> {
@@ -66,22 +53,11 @@ public extension StytchClient.Sessions {
 // MARK: - revoke Async/Await
 #if compiler(>=5.5) && canImport(_Concurrency)
 public extension StytchClient.Sessions {
-    #if compiler(>=5.5.2)
     /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func revoke() async throws -> SessionsRevokeResponse {
         try await withCheckedThrowingContinuation { continuation in
             revoke(completion: continuation.resume)
         }
     }
-    #else
-    /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func revoke() async throws -> SessionsRevokeResponse {
-        try await withCheckedThrowingContinuation { continuation in
-            revoke(completion: continuation.resume)
-        }
-    }
-    #endif
 }
 #endif

--- a/Sources/StytchCore/KeychainClient/KeychainClient.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient.swift
@@ -49,14 +49,11 @@ extension KeychainClient {
         var name: String
 
         var baseQuery: [CFString: Any] {
-            var query: [CFString: Any] = [
+            [
                 kSecClass: secClass,
                 kSecAttrAccount: name,
+                kSecUseDataProtectionKeychain: true,
             ]
-            if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
-                query[kSecUseDataProtectionKeychain] = true
-            }
-            return query
         }
 
         var getQuery: CFDictionary {

--- a/Sources/StytchCore/SessionStorage.swift
+++ b/Sources/StytchCore/SessionStorage.swift
@@ -120,12 +120,10 @@ final class SessionStorage {
             .path: "/",
             .domain: hostUrl.host ?? hostUrl.absoluteString,
             .expires: expiresAt,
+            .sameSitePolicy: HTTPCookieStringPolicy.sameSiteLax,
         ]
         if !urlComponents.isLocalHost {
             properties[.secure] = true
-        }
-        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
-            properties[.sameSitePolicy] = HTTPCookieStringPolicy.sameSiteLax
         }
 
         return HTTPCookie(properties: properties)

--- a/Stytch.podspec
+++ b/Stytch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Stytch'
-  s.version      = '0.1.0'
+  s.version      = '0.2.0'
   s.summary      = "A Swift SDK for using Stytch's user-authentication products on Apple platforms."
   s.homepage     = 'https://github.com/stytchauth/stytch-swift'
   s.license      = {
@@ -15,9 +15,9 @@ Pod::Spec.new do |s|
     :tag => s.version.to_s
   }
 
-  s.ios.deployment_target  = '11.3'
-  s.osx.deployment_target  = '10.13'
-  s.tvos.deployment_target = '11.3'
+  s.ios.deployment_target  = '13.0'
+  s.osx.deployment_target  = '10.15'
+  s.tvos.deployment_target = '13.0'
 
   s.swift_version = '5.5'
 

--- a/Tests/StytchCoreTests/AsyncMethodsTestCase.swift
+++ b/Tests/StytchCoreTests/AsyncMethodsTestCase.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import StytchCore
 
-@available(iOS 13.0, *)
 final class AsyncMethodsTestCase: BaseTestCase {
     func testMagicLinksEmailLoginOrCreate() async throws {
         let container = DataContainer(data: BasicResponse(requestId: "1234", statusCode: 200))
@@ -154,7 +153,6 @@ final class AsyncMethodsTestCase: BaseTestCase {
         XCTAssertNil(StytchClient.sessions.sessionToken)
     }
 
-    @available(iOS 13.0, *)
     func testOtpLoginOrCreate() async throws {
         let container: DataContainer<StytchClient.OneTimePasscodes.LoginOrCreateResponse> = .init(
             data: .init(


### PR DESCRIPTION
To reduce the complexity for various upcoming features and the associated security concerns, and to reduce overall complexity as it pertains to ongoing internal maintenance, we have decided to update our minimum deployment target to iOS 13. Among other things this will allow us to base the internal async mechanisms off of Swift's modern Async/Await concurrency systems. We will, however, still provide Combine and Completion-handler hooks for external consumption.

Based on our analysis, as of last month, iOS users on versions < iOS 13.0 made up roughly 5% of total iOS users worldwide. Given this SDK is a net-new product, we are choosing to begin its lifetime without the technical debt of managing older OS versions. We will, in the near future, create a formal policy for supported iOS versions which we expect to look something like `current major version minus 3` following the rollout of iOS 16.