### PR TITLE
[refactor] Add keychain migrations

### DIFF
--- a/Sources/StytchCore/KeychainClient/KeychainClient+Live.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient+Live.swift
@@ -2,47 +2,42 @@ import Foundation
 import Security
 
 extension KeychainClient {
-    static let live: Self = .init(
-        getItem: { item in
-            var result: CFTypeRef?
+    static let live: Self = .init { item in
+        var result: CFTypeRef?
 
-            guard case errSecSuccess = SecItemCopyMatching(item.getQuery, &result) else {
-                return nil
-            }
-            guard let data = result as? Data else {
-                throw KeychainError.resultNotData
-            }
-
-            return String(data: data, encoding: .utf8)
-        },
-        setValueForItem: { client, value, item in
-            let status: OSStatus
-
-            if client.resultExists(for: item) {
-                status = SecItemUpdate(
-                    item.baseQuery as CFDictionary,
-                    item.querySegmentForUpdate(for: value) as CFDictionary
-                )
-            } else {
-                status = SecItemAdd(item.insertQuery(value: value), nil)
-            }
-            if status != errSecSuccess {
-                throw KeychainError.unhandledError(status: status)
-            }
-        },
-        removeItem: { client, item in
-            guard client.resultExists(for: item) else {
-                return
-            }
-
-            let status = SecItemDelete(item.baseQuery as CFDictionary)
-
-            if status != errSecSuccess {
-                throw KeychainError.unhandledError(status: status)
-            }
-        },
-        resultExists: { item in
-            SecItemCopyMatching(item.baseQuery as CFDictionary, nil) == errSecSuccess
+        guard case errSecSuccess = SecItemCopyMatching(item.getQuery, &result) else {
+            return nil
         }
-    )
+        guard let data = result as? Data else {
+            throw KeychainError.resultNotData
+        }
+
+        return String(data: data, encoding: .utf8)
+    } setValueForItem: { client, value, item in
+        let status: OSStatus
+
+        if client.resultExists(for: item) {
+            status = SecItemUpdate(
+                item.baseQuery as CFDictionary,
+                item.querySegmentForUpdate(for: value) as CFDictionary
+            )
+        } else {
+            status = SecItemAdd(item.insertQuery(value: value), nil)
+        }
+        if status != errSecSuccess {
+            throw KeychainError.unhandledError(status: status)
+        }
+    } removeItem: { client, item in
+        guard client.resultExists(for: item) else {
+            return
+        }
+
+        let status = SecItemDelete(item.baseQuery as CFDictionary)
+
+        if status != errSecSuccess {
+            throw KeychainError.unhandledError(status: status)
+        }
+    } resultExists: { item in
+        SecItemCopyMatching(item.baseQuery as CFDictionary, nil) == errSecSuccess
+    }
 }

--- a/Sources/StytchCore/KeychainClient/KeychainClient.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient.swift
@@ -50,8 +50,8 @@ extension KeychainClient {
 
         var baseQuery: [CFString: Any] {
             [
-                kSecClass: secClass,
-                kSecAttrAccount: name,
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: name,
                 kSecUseDataProtectionKeychain: true,
             ]
         }
@@ -70,13 +70,6 @@ extension KeychainClient {
 
         func querySegmentForUpdate(for value: String) -> [CFString: Any] {
             [kSecValueData: Data(value.utf8)]
-        }
-
-        private var secClass: CFString {
-            switch kind {
-            case .token:
-                return kSecClassGenericPassword
-            }
         }
     }
 

--- a/Sources/StytchCore/KeychainClient/KeychainMigration.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainMigration.swift
@@ -5,6 +5,6 @@ protocol KeychainMigration {
 extension KeychainClient {
     // Migrations must only be added to the bottom of this list so they are run in order
     static let migrations: [KeychainMigration.Type] = [
-        Migration1.self
+        Migration1.self,
     ]
 }

--- a/Sources/StytchCore/KeychainClient/KeychainMigration.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainMigration.swift
@@ -1,0 +1,10 @@
+protocol KeychainMigration {
+    static func run() throws
+}
+
+extension KeychainClient {
+    // Migrations must only be added to the bottom of this list so they are run in order
+    static let migrations: [KeychainMigration.Type] = [
+        Migration1.self
+    ]
+}

--- a/Sources/StytchCore/KeychainClient/Migrations/Migration1.swift
+++ b/Sources/StytchCore/KeychainClient/Migrations/Migration1.swift
@@ -1,0 +1,21 @@
+import Security
+
+extension KeychainClient {
+    struct Migration1: KeychainMigration {
+        static func run() throws {
+            try [
+                KeychainClient.Item.sessionJwt,
+                .sessionToken,
+                .stytchPKCECodeVerifier,
+            ].forEach { item in
+                let status = SecItemUpdate(
+                    [kSecAttrAccount: item.name, kSecClass: kSecClassGenericPassword] as CFDictionary,
+                    [kSecAttrService: item.name] as CFDictionary
+                )
+                guard [errSecSuccess, errSecItemNotFound].contains(status) else {
+                    throw KeychainError.unhandledError(status: status)
+                }
+            }
+        }
+    }
+}

--- a/Sources/StytchCore/KeychainClient/Migrations/Migration1.swift
+++ b/Sources/StytchCore/KeychainClient/Migrations/Migration1.swift
@@ -7,7 +7,8 @@ extension KeychainClient {
                 KeychainClient.Item.sessionJwt,
                 .sessionToken,
                 .stytchPKCECodeVerifier,
-            ].forEach { item in
+            ]
+            .forEach { item in
                 let status = SecItemUpdate(
                     [kSecAttrAccount: item.name, kSecClass: kSecClassGenericPassword] as CFDictionary,
                     [kSecAttrService: item.name] as CFDictionary

--- a/Sources/StytchCore/SessionStorage.swift
+++ b/Sources/StytchCore/SessionStorage.swift
@@ -136,7 +136,7 @@ final class SessionStorage {
     }
 }
 
-private extension KeychainClient.Item {
+extension KeychainClient.Item {
     static let sessionToken: Self = .init(kind: .token, name: Session.Token.Kind.opaque.name)
     static let sessionJwt: Self = .init(kind: .token, name: Session.Token.Kind.jwt.name)
 }

--- a/Sources/StytchCore/StytchClient/StytchClient+Environment.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient+Environment.swift
@@ -43,6 +43,8 @@ extension StytchClient {
             return encoder
         }()
 
+        var defaults: UserDefaults = .standard
+
         var networkingClient: NetworkingClient = .live
 
         let cryptoClient: CryptoClient = .init()

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -21,6 +21,7 @@ public struct StytchClient {
 
     private init() {
         updateHeaderProvider()
+        runKeychainMigrations()
     }
 
     /**
@@ -85,6 +86,21 @@ public struct StytchClient {
                 "Authorization": "Basic \(authToken)",
                 "X-SDK-Client": clientInfoString ?? "",
             ]
+        }
+    }
+
+    private func runKeychainMigrations() {
+        KeychainClient.migrations.forEach { migration in
+            let migrationName = "stytch_keychain_migration_" + String(describing: migration.self)
+            guard !Current.defaults.bool(forKey: migrationName) else {
+                return
+            }
+            do {
+                try migration.run()
+                Current.defaults.set(true, forKey: migrationName)
+            } catch {
+                print(error)
+            }
         }
     }
 }

--- a/Tests/StytchCoreTests/KeychainClientTestCase.swift
+++ b/Tests/StytchCoreTests/KeychainClientTestCase.swift
@@ -31,7 +31,7 @@ final class KeychainClientTestCase: BaseTestCase {
 
         XCTAssertEqual(
             item.getQuery,
-            ["acct": "item", "class": "genp", "m_Limit": "m_LimitOne", "r_Data": 1, "nleg": 1] as CFDictionary
+            ["svce": "item", "class": "genp", "m_Limit": "m_LimitOne", "r_Data": 1, "nleg": 1] as CFDictionary
         )
         XCTAssertEqual(
             item.querySegmentForUpdate(for: "value") as CFDictionary,
@@ -39,7 +39,7 @@ final class KeychainClientTestCase: BaseTestCase {
         )
         XCTAssertEqual(
             item.insertQuery(value: "new_value") as CFDictionary,
-            ["acct": "item", "class": "genp", "v_Data": Data("new_value".utf8), "nleg": 1] as CFDictionary
+            ["svce": "item", "class": "genp", "v_Data": Data("new_value".utf8), "nleg": 1] as CFDictionary
         )
     }
 }


### PR DESCRIPTION
For consistency with upcoming keychain items, we are migrating all items to use kSecAttrService instead of kSecAttrAccount as the key corresponding to the KeychainClient.Item name property. This PR makes that change and introduces keychain migrations to accomodate this, and future, changes.