### PR TITLE
[refactor] Adjust KeychainClient to return array of results

### DIFF
--- a/Sources/StytchCore/KeychainClient/KeychainClient+Live.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient+Live.swift
@@ -13,9 +13,7 @@ extension KeychainClient {
         }
 
         return try results.compactMap { dict in
-            guard let data = dict[kSecValueData] as? Data else {
-                throw KeychainError.resultNotData
-            }
+            guard let data = dict[kSecValueData] as? Data else { throw KeychainError.resultNotData }
             guard let account = dict[kSecAttrAccount] as? String else { throw KeychainError.resultMissingAccount }
             guard
                 let createdAt = dict[kSecAttrCreationDate] as? Date,

--- a/Sources/StytchCore/KeychainClient/KeychainClient.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient.swift
@@ -84,7 +84,8 @@ extension KeychainClient {
             baseQuery
                 .merging([
                     kSecReturnData: true,
-                    kSecMatchLimit: kSecMatchLimitOne,
+                    kSecReturnAttributes: true,
+                    kSecMatchLimit: kSecMatchLimitAll,
                 ]) { $1 } as CFDictionary
         }
 

--- a/Sources/StytchCore/KeychainClient/KeychainClient.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient.swift
@@ -1,40 +1,66 @@
 import Foundation
 
 struct KeychainClient {
-    private let getItem: (Item) throws -> String?
+    private let get: (Item) throws -> [QueryResult]
 
-    private let setValueForItem: (Self, String, Item) throws -> Void
+    let setValueForItem: (Self, ItemData, Item) throws -> Void
 
-    private let removeItem: (Self, Item) throws -> Void
+    let removeItem: (Item) throws -> Void
 
-    private let resultExists: (Item) -> Bool
+    let resultsExistForItem: (Item) -> Bool
 
     init(
-        getItem: @escaping (KeychainClient.Item) throws -> String?,
-        setValueForItem: @escaping (KeychainClient, String, KeychainClient.Item) throws -> Void,
-        removeItem: @escaping (KeychainClient, KeychainClient.Item) throws -> Void,
-        resultExists: @escaping (KeychainClient.Item) -> Bool
+        get: @escaping (Item) throws -> [QueryResult],
+        setValueForItem: @escaping (Self, ItemData, Item) throws -> Void,
+        removeItem: @escaping (Item) throws -> Void,
+        resultsExistForItem: @escaping (Item) -> Bool
     ) {
-        self.getItem = getItem
+        self.get = get
         self.setValueForItem = setValueForItem
         self.removeItem = removeItem
-        self.resultExists = resultExists
+        self.resultsExistForItem = resultsExistForItem
     }
+}
 
+// String convenience methods
+extension KeychainClient {
     func get(_ item: Item) throws -> String? {
-        try getItem(item)
+        try get(item)
+            .first
+            .flatMap { String(data: $0.data, encoding: .utf8) }
     }
 
     func set(_ value: String, for item: Item) throws {
-        try setValueForItem(self, value, item)
+        try setValueForItem(
+            self,
+            .init(data: .init(value.utf8), account: nil, label: nil, generic: nil, accessControl: nil),
+            item
+        )
+    }
+}
+
+extension KeychainClient {
+    struct QueryResult {
+        let data: Data
+        let createdAt: Date
+        let modifiedAt: Date
+        let label: String?
+        let account: String
+        let generic: Data?
     }
 
-    func remove(_ item: Item) throws {
-        try removeItem(self, item)
-    }
+    struct ItemData {
+        let data: Data
+        let account: String?
+        let label: String?
+        let generic: Data?
+        let accessControl: AccessControl?
 
-    func resultExists(for item: Item) -> Bool {
-        resultExists(item)
+        enum AccessControl {
+            var value: SecAccessControl {
+                switch self {}
+            }
+        }
     }
 }
 
@@ -64,16 +90,35 @@ extension KeychainClient {
                 ]) { $1 } as CFDictionary
         }
 
-        func insertQuery(value: String) -> CFDictionary {
-            baseQuery.merging(querySegmentForUpdate(for: value)) { $1 } as CFDictionary
+        func insertQuery(itemData: ItemData) -> CFDictionary {
+            baseQuery.merging(updateQuerySegment(for: itemData))
         }
 
-        func querySegmentForUpdate(for value: String) -> [CFString: Any] {
-            [kSecValueData: Data(value.utf8)]
+        func updateQuerySegment(for itemData: ItemData) -> [CFString: Any] {
+            var querySegment: [CFString: Any] = [
+                kSecValueData: itemData.data,
+            ]
+            if let account = itemData.account {
+                querySegment[kSecAttrAccount] = account
+            }
+            if let label = itemData.label {
+                querySegment[kSecAttrLabel] = label
+            }
+            if let generic = itemData.generic {
+                querySegment[kSecAttrGeneric] = generic
+            }
+            if let accessControl = itemData.accessControl?.value {
+                querySegment[kSecAttrAccessControl] = accessControl // FIXME: - messed up on ios 15 simulator
+            }
+            return querySegment
         }
+
     }
 
     enum KeychainError: Swift.Error {
+        case resultMissingAccount
+        case resultMissingDates
+        case resultNotArray
         case resultNotData
         case unhandledError(status: OSStatus)
     }
@@ -81,4 +126,10 @@ extension KeychainClient {
 
 extension KeychainClient.Item {
     static let stytchPKCECodeVerifier: Self = .init(kind: .token, name: "stytch_pkce_code_verifier")
+}
+
+extension Dictionary where Key == CFString, Value == Any {
+    func merging(_ other: Self) -> CFDictionary {
+        self.merging(other) { $1 } as CFDictionary
+    }
 }

--- a/Sources/StytchCore/KeychainClient/KeychainClient.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient.swift
@@ -62,9 +62,7 @@ extension KeychainClient {
             }
         }
     }
-}
 
-extension KeychainClient {
     struct Item {
         enum Kind {
             case token
@@ -112,7 +110,6 @@ extension KeychainClient {
             }
             return querySegment
         }
-
     }
 
     enum KeychainError: Swift.Error {
@@ -130,6 +127,6 @@ extension KeychainClient.Item {
 
 extension Dictionary where Key == CFString, Value == Any {
     func merging(_ other: Self) -> CFDictionary {
-        self.merging(other) { $1 } as CFDictionary
+        merging(other) { $1 } as CFDictionary
     }
 }

--- a/Sources/StytchCore/SessionStorage.swift
+++ b/Sources/StytchCore/SessionStorage.swift
@@ -13,7 +13,7 @@ final class SessionStorage {
                 if let newValue = newValue {
                     try? Current.keychainClient.set(newValue.value, for: keychainItem)
                 } else {
-                    try? Current.keychainClient.remove(keychainItem)
+                    try? Current.keychainClient.removeItem(keychainItem)
                     Current.cookieClient.deleteCookie(named: keychainItem.name)
                 }
             }
@@ -32,7 +32,7 @@ final class SessionStorage {
                 if let newValue = newValue {
                     try? Current.keychainClient.set(newValue.value, for: keychainItem)
                 } else {
-                    try? Current.keychainClient.remove(keychainItem)
+                    try? Current.keychainClient.removeItem(keychainItem)
                     Current.cookieClient.deleteCookie(named: keychainItem.name)
                 }
             }

--- a/Sources/StytchCore/StytchClient/Sessions/StytchClient+PKCE.swift
+++ b/Sources/StytchCore/StytchClient/Sessions/StytchClient+PKCE.swift
@@ -16,7 +16,7 @@ extension StytchClient {
     static func pckeAuthenticateCompletion<T>(_ completion: @escaping Completion<T>) -> Completion<T> {
         { result in
             if case .success = result {
-                try? Current.keychainClient.remove(.stytchPKCECodeVerifier)
+                try? Current.keychainClient.removeItem(.stytchPKCECodeVerifier)
             }
             completion(result)
         }

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -24,7 +24,7 @@ class BaseTestCase: XCTestCase {
             get: { [unowned self] in self.keychainItems[$0.name] ?? [] },
             setValueForItem: { [unowned self] _, value, item in
                 self.keychainItems[item.name] = [
-                    .init(data: value.data, createdAt: .init(), modifiedAt: .init(), label: item.name, account: item.name, generic: nil)
+                    .init(data: value.data, createdAt: .init(), modifiedAt: .init(), label: item.name, account: item.name, generic: nil),
                 ]
             },
             removeItem: { [unowned self] item in self.keychainItems[item.name] = nil },

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -5,7 +5,7 @@ import XCTest
 class BaseTestCase: XCTestCase {
     private(set) var cookies: [HTTPCookie] = []
 
-    private(set) var keychainItems: [String: String] = [:]
+    private(set) var keychainItems: [String: [KeychainClient.QueryResult]] = [:]
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -21,10 +21,14 @@ class BaseTestCase: XCTestCase {
         )
 
         Current.keychainClient = .init(
-            getItem: { [unowned self] in self.keychainItems[$0.name] },
-            setValueForItem: { [unowned self] _, value, item in self.keychainItems[item.name] = value },
-            removeItem: { [unowned self] _, item in self.keychainItems[item.name] = nil },
-            resultExists: { [unowned self] item in self.keychainItems[item.name] != nil }
+            get: { [unowned self] in self.keychainItems[$0.name] ?? [] },
+            setValueForItem: { [unowned self] _, value, item in
+                self.keychainItems[item.name] = [
+                    .init(data: value.data, createdAt: .init(), modifiedAt: .init(), label: item.name, account: item.name, generic: nil)
+                ]
+            },
+            removeItem: { [unowned self] item in self.keychainItems[item.name] = nil },
+            resultsExistForItem: { [unowned self] item in self.keychainItems[item.name] != nil }
         )
 
         Current.sessionsPollingClient = .failing

--- a/Tests/StytchCoreTests/KeychainClientTestCase.swift
+++ b/Tests/StytchCoreTests/KeychainClientTestCase.swift
@@ -35,7 +35,7 @@ final class KeychainClientTestCase: BaseTestCase {
 
         XCTAssertEqual(
             item.getQuery,
-            ["svce": "item", "class": "genp", "m_Limit": "m_LimitOne", "r_Data": 1, "nleg": 1] as CFDictionary
+            ["svce": "item", "class": "genp", "m_Limit": "m_LimitAll", "r_Data": 1, "r_Attributes": 1, "nleg": 1] as CFDictionary
         )
         XCTAssertEqual(
             item.updateQuerySegment(for: itemDataForValue("value")) as CFDictionary,

--- a/Tests/StytchCoreTests/KeychainClientTestCase.swift
+++ b/Tests/StytchCoreTests/KeychainClientTestCase.swift
@@ -11,8 +11,8 @@ final class KeychainClientTestCase: BaseTestCase {
 
         try Current.keychainClient.set("test test", for: item)
 
-        XCTAssertTrue(Current.keychainClient.resultExists(for: item))
-        XCTAssertFalse(Current.keychainClient.resultExists(for: otherItem))
+        XCTAssertTrue(Current.keychainClient.resultsExistForItem(item))
+        XCTAssertFalse(Current.keychainClient.resultsExistForItem(otherItem))
 
         XCTAssertEqual(try Current.keychainClient.get(item), "test test")
 
@@ -20,25 +20,29 @@ final class KeychainClientTestCase: BaseTestCase {
 
         XCTAssertEqual(try Current.keychainClient.get(item), "test again")
 
-        try Current.keychainClient.remove(item)
+        try Current.keychainClient.removeItem(item)
 
-        XCTAssertFalse(Current.keychainClient.resultExists(for: item))
-        XCTAssertFalse(Current.keychainClient.resultExists(for: otherItem))
+        XCTAssertFalse(Current.keychainClient.resultsExistForItem(item))
+        XCTAssertFalse(Current.keychainClient.resultsExistForItem(otherItem))
     }
 
     func testKeychainItem() {
         let item: KeychainClient.Item = .init(kind: .token, name: "item")
+
+        let itemDataForValue: (String) -> KeychainClient.ItemData = { value in
+            .init(data: .init(value.utf8), account: nil, label: nil, generic: nil, accessControl: nil)
+        }
 
         XCTAssertEqual(
             item.getQuery,
             ["svce": "item", "class": "genp", "m_Limit": "m_LimitOne", "r_Data": 1, "nleg": 1] as CFDictionary
         )
         XCTAssertEqual(
-            item.querySegmentForUpdate(for: "value") as CFDictionary,
+            item.updateQuerySegment(for: itemDataForValue("value")) as CFDictionary,
             ["v_Data": Data("value".utf8)] as CFDictionary
         )
         XCTAssertEqual(
-            item.insertQuery(value: "new_value") as CFDictionary,
+            item.insertQuery(itemData: itemDataForValue("new_value")) as CFDictionary,
             ["svce": "item", "class": "genp", "v_Data": Data("new_value".utf8), "nleg": 1] as CFDictionary
         )
     }


### PR DESCRIPTION
Refactors KeychainClient to take in a new ItemData struct when setting an item, but maintains string convenience methods. This sets us up to a) return multiple results for biometrics keys and b) to pass in and return additional metadata for a given keychain query result