### PR TITLE
[version] bump version & provide better checks for tag <-> version checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,13 @@ jobs:
         make setup
         make tools
 
+    - name: Ensure SDK version matches current tag
+      run: |
+        if [[ "$(Scripts/current-version)" != ${{ github.ref_name }} ]]; then
+          echo "Tag '${{ github.ref_name }}' not equal to $(Scripts/current-version)"
+          exit 1
+        fi
+
     - name: Create XCFramework
       run: |
         arch -arm64 mint run swift-create-xcframework --zip --xc-setting SKIP_INSTALL=NO --xc-setting BUILD_LIBRARY_FOR_DISTRIBUTION=YES

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
 
 concurrency:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -38,7 +38,7 @@ opt_in_rules:
   - fallthrough
   - fatal_error_message
   - file_header
-  - file_name
+# - file_name
   - file_name_no_space
 # - file_types_order
   - first_where

--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,3 @@ let package = Package(
         .testTarget(name: "StytchCoreTests", dependencies: ["StytchCore"]),
     ]
 )
-
-#if swift(>=5.6)
-// Add the documentation compiler plugin if possible
-package.dependencies.append(
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
-)
-#endif

--- a/Scripts/current-version
+++ b/Scripts/current-version
@@ -1,0 +1,11 @@
+#! /usr/bin/env ruby
+
+def project_root
+  File.expand_path('../../', __FILE__)
+end
+
+version = File.readlines(
+  File.join(project_root, 'Sources/StytchCore/ClientInfo/ClientInfo+Version.swift')
+)[1].sub(/.*major: (\d+), minor: (\d+), patch: (\d+).*/, '\1.\2.\3')
+
+puts version.strip

--- a/Sources/StytchCore/ClientInfo/ClientInfo+SDK.swift
+++ b/Sources/StytchCore/ClientInfo/ClientInfo+SDK.swift
@@ -3,6 +3,6 @@ import Foundation
 extension ClientInfo {
     struct SDK: Encodable {
         let identifier: String = "stytch-swift"
-        let version: Version = .init(major: 0, minor: 0, patch: 1)
+        let version: Version = .current
     }
 }

--- a/Sources/StytchCore/ClientInfo/ClientInfo+Version.swift
+++ b/Sources/StytchCore/ClientInfo/ClientInfo+Version.swift
@@ -1,3 +1,3 @@
 extension Version {
-    static var current: Self = .init(major: 0, minor: 0, patch: 1)
+    static let current: Self = .init(major: 0, minor: 3, patch: 0)
 }

--- a/Sources/StytchCore/ClientInfo/ClientInfo+Version.swift
+++ b/Sources/StytchCore/ClientInfo/ClientInfo+Version.swift
@@ -1,0 +1,3 @@
+extension Version {
+    static var current: Self = .init(major: 0, minor: 0, patch: 1)
+}

--- a/Stytch.podspec
+++ b/Stytch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Stytch'
-  s.version      = '0.2.0'
+  s.version      = `Scripts/current-version`.strip
   s.summary      = "A Swift SDK for using Stytch's user-authentication products on Apple platforms."
   s.homepage     = 'https://github.com/stytchauth/stytch-swift'
   s.license      = {


### PR DESCRIPTION
- Bump version to 0.3.0
- Add current_version script
- Remove redundant docc-plugin dep to fix release workflow
- Add checks in workflow that versioning matches tag name
