### PR TITLE
austin/oauth: add figma, snpachat, tiktok, twitter

### DIFF
--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
@@ -71,6 +71,7 @@ extension StytchClient.OAuth.ThirdParty {
         case microsoft
         case slack
         case snapchat
+        case spotify
         case tiktok
         case twitch
         case twitter

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
@@ -63,13 +63,17 @@ extension StytchClient.OAuth.ThirdParty {
         case coinbase
         case discord
         case facebook
+        case figma
         case github
         case gitlab
         case google
         case linkedin
         case microsoft
         case slack
+        case snapchat
+        case tiktok
         case twitch
+        case twitter
     }
 }
 #endif

--- a/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
@@ -47,6 +47,9 @@ public extension StytchClient.OAuth {
     /// The interface for authenticating a user with Facebook.
     var facebook: ThirdParty { .init(provider: .facebook) }
 
+    /// The interface for authenticating a user with Figma.
+    var figma: ThirdParty { .init(provider: .figma) }
+
     /// The interface for authenticating a user with GitHub.
     var github: ThirdParty { .init(provider: .github) }
 
@@ -65,8 +68,17 @@ public extension StytchClient.OAuth {
     /// The interface for authenticating a user with Slack.
     var slack: ThirdParty { .init(provider: .slack) }
 
+    /// The interface for authenticating a user with Snapchat.
+    var snapchat: ThirdParty { .init(provider: .snapchat) }
+
+    /// The interface for authenticating a user with TikTok.
+    var tiktok: ThirdParty { .init(provider: .tiktok) }
+
     /// The interface for authenticating a user with Twitch.
     var twitch: ThirdParty { .init(provider: .twitch) }
+
+    /// The interface for authenticating a user with Twitter.
+    var twitter: ThirdParty { .init(provider: .twitter) }
 }
 #endif
 

--- a/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
@@ -71,6 +71,9 @@ public extension StytchClient.OAuth {
     /// The interface for authenticating a user with Snapchat.
     var snapchat: ThirdParty { .init(provider: .snapchat) }
 
+    /// The interface for authenticating a user with Spotify.
+    var spotify: ThirdParty { .init(provider: .spotify) }
+
     /// The interface for authenticating a user with TikTok.
     var tiktok: ThirdParty { .init(provider: .tiktok) }
 

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -88,6 +88,8 @@ private extension StytchClient.OAuth.ThirdParty.Provider {
             return StytchClient.oauth.slack
         case .snapchat:
             return StytchClient.oauth.snapchat
+        case .spotify:
+            return StytchClient.oauth.spotify
         case .tiktok:
             return StytchClient.oauth.tiktok
         case .twitch:

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -72,6 +72,8 @@ private extension StytchClient.OAuth.ThirdParty.Provider {
             return StytchClient.oauth.discord
         case .facebook:
             return StytchClient.oauth.facebook
+        case .figma:
+            return StytchClient.oauth.figma
         case .github:
             return StytchClient.oauth.github
         case .gitlab:
@@ -84,8 +86,14 @@ private extension StytchClient.OAuth.ThirdParty.Provider {
             return StytchClient.oauth.microsoft
         case .slack:
             return StytchClient.oauth.slack
+        case .snapchat:
+            return StytchClient.oauth.snapchat
+        case .tiktok:
+            return StytchClient.oauth.tiktok
         case .twitch:
             return StytchClient.oauth.twitch
+        case .twitter:
+            return StytchClient.oauth.twitter
         }
     }
 }


### PR DESCRIPTION
add enum/interfaces for new oauth providers

Note none of them were added to `StytchDemo/Client/Shared/OAuthAuthenticationView.swift`, so to consider there

Completes SDK-690