### PR TITLE
[platform] Request testing improvements

### DIFF
--- a/Tests/StytchCoreTests/ExtensionsTestCase.swift
+++ b/Tests/StytchCoreTests/ExtensionsTestCase.swift
@@ -21,4 +21,17 @@ final class ExtensionsTestCase: BaseTestCase {
             try testIsLocalHost(urlString: urlString, expectation: expectation)
         }
     }
+
+    func testAssertRequest() async throws {
+        var request = URLRequest(url: try XCTUnwrap(URL(string: "https://www.example.com")))
+        let json: JSON = ["examplekey1": ["examplekey2": "examplevalue1"], "examplekey3": "examplevalue2"]
+        request.httpBody = try JSONEncoder().encode(json)
+        request.httpMethod = "POST"
+
+        try XCTAssertRequest(request, urlString: "https://www.example.com", method: .post, bodyContains: [
+            ("examplekey1", ["examplekey2": "examplevalue1"]),
+            ("examplekey1.examplekey2", "examplevalue1"),
+            ("examplekey3", "examplevalue2")
+        ])
+    }
 }

--- a/Tests/StytchCoreTests/ExtensionsTestCase.swift
+++ b/Tests/StytchCoreTests/ExtensionsTestCase.swift
@@ -28,10 +28,11 @@ final class ExtensionsTestCase: BaseTestCase {
         request.httpBody = try JSONEncoder().encode(json)
         request.httpMethod = "POST"
 
-        try XCTAssertRequest(request, urlString: "https://www.example.com", method: .post, bodyContains: [
-            ("examplekey1", ["examplekey2": "examplevalue1"]),
-            ("examplekey1.examplekey2", "examplevalue1"),
-            ("examplekey3", "examplevalue2")
-        ])
+        try XCTAssertRequest(
+            request,
+            urlString: "https://www.example.com",
+            method: .post,
+            bodyEquals: ["examplekey1": ["examplekey2": "examplevalue1"], "examplekey3": "examplevalue2"]
+        )
     }
 }

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -56,12 +56,12 @@ final class MagicLinksTestCase: BaseTestCase {
             request,
             urlString: "https://web.stytch.com/sdk/v1/magic_links/email/send/primary",
             method: .post,
-            bodyContains: [
-                ("code_challenge_method", "S256"),
-                ("code_challenge", "V9dLhNVhiUv_9m8cwFSzLGR9l-q6NAeLskiVZ7WsjA8"),
-                ("email", "asdf@stytch.com"),
-                ("login_magic_link_url", "https://myapp.com/login"),
-                ("login_expiration_minutes", 30),
+            bodyEquals: [
+                "code_challenge_method": "S256",
+                "code_challenge": "V9dLhNVhiUv_9m8cwFSzLGR9l-q6NAeLskiVZ7WsjA8",
+                "email": "asdf@stytch.com",
+                "login_magic_link_url": "https://myapp.com/login",
+                "login_expiration_minutes": 30,
             ]
         )
     }
@@ -94,12 +94,12 @@ final class MagicLinksTestCase: BaseTestCase {
             request,
             urlString: "https://web.stytch.com/sdk/v1/magic_links/email/send/secondary",
             method: .post,
-            bodyContains: [
-                ("code_challenge_method", "S256"),
-                ("code_challenge", "V9dLhNVhiUv_9m8cwFSzLGR9l-q6NAeLskiVZ7WsjA8"),
-                ("email", "asdf@stytch.com"),
-                ("login_magic_link_url", "https://myapp.com/login"),
-                ("login_expiration_minutes", 30),
+            bodyEquals: [
+                "code_challenge_method": "S256",
+                "code_challenge": "V9dLhNVhiUv_9m8cwFSzLGR9l-q6NAeLskiVZ7WsjA8",
+                "email": "asdf@stytch.com",
+                "login_magic_link_url": "https://myapp.com/login",
+                "login_expiration_minutes": 30,
             ]
         )
     }

--- a/Tests/StytchCoreTests/NetworkingClientTestCase.swift
+++ b/Tests/StytchCoreTests/NetworkingClientTestCase.swift
@@ -49,6 +49,26 @@ final class NetworkingClientTestCase: XCTestCase {
         }
     }
 
+    func testMockNetworkingClient() async throws {
+        StytchClient.configure(
+            publicToken: "xyz",
+            hostUrl: try XCTUnwrap(URL(string: "https://myapp.com"))
+        )
+        let container: DataContainer<StytchClient.OneTimePasscodes.OTPResponse> = .init(
+            data: .init(
+                requestId: "1234",
+                statusCode: 200,
+                wrapped: .init(methodId: "method_id_1234")
+            )
+        )
+        let data = try Current.jsonEncoder.encode(container)
+        Current.networkingClient = .mock(returning: .success(data))
+        let response: StytchClient.OneTimePasscodes.OTPResponse = try await StytchClient.router.get(route: .otps(.authenticate))
+        XCTAssertEqual(response.methodId, "method_id_1234")
+        XCTAssertEqual(response.requestId, "1234")
+        XCTAssertEqual(response.statusCode, 200)
+    }
+
     private func verifyRequest(
         _ method: NetworkingClient.Method = .get,
         url: URL? = nil,

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -11,9 +11,16 @@ final class OAuthTestCase: BaseTestCase {
         Current.timer = { _, _, _ in .init() }
         _ = try await StytchClient.oauth.apple.start(parameters: .init())
 
-        XCTAssertEqual(
-            request.httpBody,
-            Data("{\"session_duration_minutes\":30,\"nonce\":\"e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741\",\"id_token\":\"id_token_123\",\"name\":{\"first_name\":\"user\"}}".utf8)
+        try XCTAssertRequest(
+            request,
+            urlString: "https://web.stytch.com/sdk/v1/oauth/apple/id_token/authenticate",
+            method: .post,
+            bodyContains: [
+                ("session_duration_minutes", 30),
+                ("nonce", "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741"),
+                ("id_token", "id_token_123"),
+                ("name.first_name", "user"),
+            ]
         )
     }
 
@@ -26,9 +33,15 @@ final class OAuthTestCase: BaseTestCase {
         _ = try StytchClient.generateAndStorePKCE(keychainItem: .oauthPKCECodeVerifier)
         _ = try await StytchClient.oauth.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12))
 
-        XCTAssertEqual(
-            request.httpBody,
-            .init("{\"token\":\"i-am-token\",\"session_duration_minutes\":12,\"code_verifier\":\"e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741\"}".utf8)
+        try XCTAssertRequest(
+            request,
+            urlString: "https://web.stytch.com/sdk/v1/oauth/authenticate",
+            method: .post,
+            bodyContains: [
+                ("session_duration_minutes", 12),
+                ("code_verifier", "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741"),
+                ("token", "i-am-token"),
+            ]
         )
     }
 }

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -15,11 +15,11 @@ final class OAuthTestCase: BaseTestCase {
             request,
             urlString: "https://web.stytch.com/sdk/v1/oauth/apple/id_token/authenticate",
             method: .post,
-            bodyContains: [
-                ("session_duration_minutes", 30),
-                ("nonce", "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741"),
-                ("id_token", "id_token_123"),
-                ("name.first_name", "user"),
+            bodyEquals: [
+                "session_duration_minutes": 30,
+                "nonce": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
+                "id_token": "id_token_123",
+                "name": ["first_name": "user"],
             ]
         )
     }
@@ -37,10 +37,10 @@ final class OAuthTestCase: BaseTestCase {
             request,
             urlString: "https://web.stytch.com/sdk/v1/oauth/authenticate",
             method: .post,
-            bodyContains: [
-                ("session_duration_minutes", 12),
-                ("code_verifier", "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741"),
-                ("token", "i-am-token"),
+            bodyEquals: [
+                "session_duration_minutes": 12,
+                "code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
+                "token": "i-am-token",
             ]
         )
     }

--- a/Tests/StytchCoreTests/OneTimePasscodesTestCase.swift
+++ b/Tests/StytchCoreTests/OneTimePasscodesTestCase.swift
@@ -18,23 +18,23 @@ final class OneTimePasscodesTestCase: BaseTestCase {
             (
                 StytchClient.OneTimePasscodes.Parameters(deliveryMethod: .whatsapp(phoneNumber: "+12345678901"), expiration: 3),
                 "https://web.stytch.com/sdk/v1/otps/whatsapp/login_or_create",
-                [("expiration_minutes", 3), ("phone_number", JSON.string("+12345678901"))]
+                JSON.object(["expiration_minutes": 3, "phone_number": "+12345678901"])
             ),
             (
                 .init(deliveryMethod: .sms(phoneNumber: "+11098765432")),
                 "https://web.stytch.com/sdk/v1/otps/sms/login_or_create",
-                [("phone_number", "+11098765432")]
+                ["phone_number": "+11098765432"]
             ),
             (
                 .init(deliveryMethod: .email("test@stytch.com")),
                 "https://web.stytch.com/sdk/v1/otps/email/login_or_create",
-                [("email", "test@stytch.com")]
+                ["email": "test@stytch.com"]
             ),
         ]
-        .asyncForEach { params, urlString, bodyContains in
+        .asyncForEach { params, urlString, bodyEquals in
             _ = try await StytchClient.otps.loginOrCreate(parameters: params)
 
-            try XCTAssertRequest(request, urlString: urlString, method: .post, bodyContains: bodyContains)
+            try XCTAssertRequest(request, urlString: urlString, method: .post, bodyEquals: bodyEquals)
 
             XCTAssertNil(StytchClient.sessions.sessionJwt)
             XCTAssertNil(StytchClient.sessions.sessionToken)
@@ -59,26 +59,23 @@ final class OneTimePasscodesTestCase: BaseTestCase {
             .init(
                 parameters: .init(deliveryMethod: .whatsapp(phoneNumber: "+12345678901"), expiration: 3),
                 urlString: "https://web.stytch.com/sdk/v1/otps/whatsapp/send/primary",
-                bodyContains: [
-                    ("expiration_minutes", 3),
-                    ("phone_number", "+12345678901"),
-                ]
+                bodyEquals: ["expiration_minutes": 3, "phone_number": "+12345678901"]
             ),
             .init(
                 parameters: .init(deliveryMethod: .sms(phoneNumber: "+11098765432")),
                 urlString: "https://web.stytch.com/sdk/v1/otps/sms/send/primary",
-                bodyContains: [("phone_number", "+11098765432")]
+                bodyEquals: ["phone_number": "+11098765432"]
             ),
             .init(
                 parameters: .init(deliveryMethod: .email("test@stytch.com")),
                 urlString: "https://web.stytch.com/sdk/v1/otps/email/send/primary",
-                bodyContains: [("email", "test@stytch.com")]
+                bodyEquals: ["email": "test@stytch.com"]
             ),
         ]
         try await expectedValues.asyncForEach { expected in
             _ = try await StytchClient.otps.send(parameters: expected.parameters)
 
-            try XCTAssertRequest(request, urlString: expected.urlString, method: .post, bodyContains: expected.bodyContains)
+            try XCTAssertRequest(request, urlString: expected.urlString, method: .post, bodyEquals: expected.bodyEquals)
 
             XCTAssertNil(StytchClient.sessions.sessionJwt)
             XCTAssertNil(StytchClient.sessions.sessionToken)
@@ -105,25 +102,22 @@ final class OneTimePasscodesTestCase: BaseTestCase {
             .init(
                 parameters: .init(deliveryMethod: .whatsapp(phoneNumber: "+12345678901"), expiration: 3),
                 urlString: "https://web.stytch.com/sdk/v1/otps/whatsapp/send/secondary",
-                bodyContains: [
-                    ("expiration_minutes", 3),
-                    ("phone_number", "+12345678901"),
-                ]
+                bodyEquals: ["expiration_minutes": 3, "phone_number": "+12345678901"]
             ),
             .init(
                 parameters: .init(deliveryMethod: .sms(phoneNumber: "+11098765432")),
                 urlString: "https://web.stytch.com/sdk/v1/otps/sms/send/secondary",
-                bodyContains: [("phone_number", "+11098765432")]
+                bodyEquals: ["phone_number": "+11098765432"]
             ),
             .init(
                 parameters: .init(deliveryMethod: .email("test@stytch.com")),
                 urlString: "https://web.stytch.com/sdk/v1/otps/email/send/secondary",
-                bodyContains: [("email", "test@stytch.com")]
+                bodyEquals: ["email": "test@stytch.com"]
             ),
         ]
         try await expectedValues.asyncForEach { expected in
             _ = try await StytchClient.otps.send(parameters: expected.parameters)
-            try XCTAssertRequest(request, urlString: expected.urlString, method: .post, bodyContains: expected.bodyContains)
+            try XCTAssertRequest(request, urlString: expected.urlString, method: .post, bodyEquals: expected.bodyEquals)
         }
     }
 
@@ -149,10 +143,10 @@ final class OneTimePasscodesTestCase: BaseTestCase {
         XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("hello_session"))
         XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("jwt_for_me"))
 
-        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/otps/authenticate", method: .post, bodyContains: [
-            ("token", "i_am_code"),
-            ("method_id", "method_id_fake_id"),
-            ("session_duration_minutes", 20),
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/otps/authenticate", method: .post, bodyEquals: [
+            "token": "i_am_code",
+            "method_id": "method_id_fake_id",
+            "session_duration_minutes": 20,
         ])
     }
 }
@@ -161,6 +155,6 @@ private extension OneTimePasscodesTestCase {
     struct ExpectedValues {
         let parameters: StytchClient.OneTimePasscodes.Parameters
         let urlString: String
-        let bodyContains: [(String, JSON)]
+        let bodyEquals: JSON
     }
 }

--- a/Tests/StytchCoreTests/PasskeysTestCase.swift
+++ b/Tests/StytchCoreTests/PasskeysTestCase.swift
@@ -25,12 +25,12 @@ final class PasskeysTestCase: BaseTestCase {
             )
         }
         _ = try await StytchClient.passkeys.register(parameters: .init(domain: "something.blah.com", username: "test@stytch.com"))
-        try XCTAssertRequest(requests[0], urlString: "https://web.stytch.com/sdk/v1/webauthn/register/start", method: .post, bodyContains: [
-            ("username", "test@stytch.com"),
-            ("domain", "something.blah.com"),
+        try XCTAssertRequest(requests[0], urlString: "https://web.stytch.com/sdk/v1/webauthn/register/start", method: .post, bodyEquals: [
+            "username": "test@stytch.com",
+            "domain": "something.blah.com",
         ])
-        try XCTAssertRequest(requests[1], urlString: "https://web.stytch.com/sdk/v1/webauthn/register", method: .post, bodyContains: [
-            ("public_key_credential", "{\"rawId\":\"ZmFrZV9pZA\",\"id\":\"ZmFrZV9pZA\",\"response\":{\"clientDataJSON\":\"ZmFrZV9qc29u\",\"attestationObject\":\"ZmFrZV9hdHRlc3RhdGlvbl9kYXRh\"},\"type\":\"public-key\"}"),
+        try XCTAssertRequest(requests[1], urlString: "https://web.stytch.com/sdk/v1/webauthn/register", method: .post, bodyEquals: [
+            "public_key_credential": "{\"rawId\":\"ZmFrZV9pZA\",\"id\":\"ZmFrZV9pZA\",\"response\":{\"clientDataJSON\":\"ZmFrZV9qc29u\",\"attestationObject\":\"ZmFrZV9hdHRlc3RhdGlvbl9kYXRh\"},\"type\":\"public-key\"}",
         ])
     }
 
@@ -69,12 +69,12 @@ final class PasskeysTestCase: BaseTestCase {
         #else
         XCTAssertFalse(requestBehaviorIsAutoFill)
         #endif
-        try XCTAssertRequest(requests[0], urlString: "https://web.stytch.com/sdk/v1/webauthn/authenticate/start", method: .post, bodyContains: [
-            ("domain", "something.blah.com"),
+        try XCTAssertRequest(requests[0], urlString: "https://web.stytch.com/sdk/v1/webauthn/authenticate/start", method: .post, bodyEquals: [
+            "domain": "something.blah.com",
         ])
-        try XCTAssertRequest(requests[1], urlString: "https://web.stytch.com/sdk/v1/webauthn/authenticate", method: .post, bodyContains: [
-            ("public_key_credential", "{\"rawId\":\"ZmFrZV9pZA\",\"id\":\"ZmFrZV9pZA\",\"response\":{\"clientDataJSON\":\"ZmFrZV9qc29u\",\"signature\":\"ZmFrZV9zaWduYXR1cmU\",\"authenticatorData\":\"ZmFrZV9hdXRoX2RhdGE\",\"userHandle\":\"ZmFrZV91c2VyX2lk\"},\"type\":\"public-key\"}"),
-            ("session_duration_minutes", 30),
+        try XCTAssertRequest(requests[1], urlString: "https://web.stytch.com/sdk/v1/webauthn/authenticate", method: .post, bodyEquals: [
+            "public_key_credential": "{\"rawId\":\"ZmFrZV9pZA\",\"id\":\"ZmFrZV9pZA\",\"response\":{\"clientDataJSON\":\"ZmFrZV9qc29u\",\"signature\":\"ZmFrZV9zaWduYXR1cmU\",\"authenticatorData\":\"ZmFrZV9hdXRoX2RhdGE\",\"userHandle\":\"ZmFrZV91c2VyX2lk\"},\"type\":\"public-key\"}",
+            "session_duration_minutes": 30,
         ])
     }
 }

--- a/Tests/StytchCoreTests/PasskeysTestCase.swift
+++ b/Tests/StytchCoreTests/PasskeysTestCase.swift
@@ -25,11 +25,13 @@ final class PasskeysTestCase: BaseTestCase {
             )
         }
         _ = try await StytchClient.passkeys.register(parameters: .init(domain: "something.blah.com", username: "test@stytch.com"))
-        XCTAssertEqual(requests[0].httpBody, Data("{\"username\":\"test@stytch.com\",\"domain\":\"something.blah.com\"}".utf8))
-        XCTAssertEqual(requests[1].httpBody, Data("{\"public_key_credential\":\"{\\\"rawId\\\":\\\"ZmFrZV9pZA\\\",\\\"id\\\":\\\"ZmFrZV9pZA\\\",\\\"response\\\":{\\\"clientDataJSON\\\":\\\"ZmFrZV9qc29u\\\",\\\"attestationObject\\\":\\\"ZmFrZV9hdHRlc3RhdGlvbl9kYXRh\\\"},\\\"type\\\":\\\"public-key\\\"}\"}".utf8))
-        XCTAssertEqual(requests[0].url?.absoluteString, "https://web.stytch.com/sdk/v1/webauthn/register/start")
-        XCTAssertEqual(requests[1].url?.absoluteString, "https://web.stytch.com/sdk/v1/webauthn/register")
-        XCTAssertTrue(requests.allSatisfy { $0.httpMethod == "POST" })
+        try XCTAssertRequest(requests[0], urlString: "https://web.stytch.com/sdk/v1/webauthn/register/start", method: .post, bodyContains: [
+            ("username", "test@stytch.com"),
+            ("domain", "something.blah.com"),
+        ])
+        try XCTAssertRequest(requests[1], urlString: "https://web.stytch.com/sdk/v1/webauthn/register", method: .post, bodyContains: [
+            ("public_key_credential", "{\"rawId\":\"ZmFrZV9pZA\",\"id\":\"ZmFrZV9pZA\",\"response\":{\"clientDataJSON\":\"ZmFrZV9qc29u\",\"attestationObject\":\"ZmFrZV9hdHRlc3RhdGlvbl9kYXRh\"},\"type\":\"public-key\"}"),
+        ])
     }
 
     func testAuthenticate() async throws {
@@ -67,11 +69,13 @@ final class PasskeysTestCase: BaseTestCase {
         #else
         XCTAssertFalse(requestBehaviorIsAutoFill)
         #endif
-        XCTAssertEqual(requests[0].httpBody, Data("{\"domain\":\"something.blah.com\"}".utf8))
-        XCTAssertEqual(requests[1].httpBody, Data("{\"session_duration_minutes\":30,\"public_key_credential\":\"{\\\"rawId\\\":\\\"ZmFrZV9pZA\\\",\\\"id\\\":\\\"ZmFrZV9pZA\\\",\\\"response\\\":{\\\"clientDataJSON\\\":\\\"ZmFrZV9qc29u\\\",\\\"signature\\\":\\\"ZmFrZV9zaWduYXR1cmU\\\",\\\"authenticatorData\\\":\\\"ZmFrZV9hdXRoX2RhdGE\\\",\\\"userHandle\\\":\\\"ZmFrZV91c2VyX2lk\\\"},\\\"type\\\":\\\"public-key\\\"}\"}".utf8))
-        XCTAssertEqual(requests[0].url?.absoluteString, "https://web.stytch.com/sdk/v1/webauthn/authenticate/start")
-        XCTAssertEqual(requests[1].url?.absoluteString, "https://web.stytch.com/sdk/v1/webauthn/authenticate")
-        XCTAssertTrue(requests.allSatisfy { $0.httpMethod == "POST" })
+        try XCTAssertRequest(requests[0], urlString: "https://web.stytch.com/sdk/v1/webauthn/authenticate/start", method: .post, bodyContains: [
+            ("domain", "something.blah.com"),
+        ])
+        try XCTAssertRequest(requests[1], urlString: "https://web.stytch.com/sdk/v1/webauthn/authenticate", method: .post, bodyContains: [
+            ("public_key_credential", "{\"rawId\":\"ZmFrZV9pZA\",\"id\":\"ZmFrZV9pZA\",\"response\":{\"clientDataJSON\":\"ZmFrZV9qc29u\",\"signature\":\"ZmFrZV9zaWduYXR1cmU\",\"authenticatorData\":\"ZmFrZV9hdXRoX2RhdGE\",\"userHandle\":\"ZmFrZV91c2VyX2lk\"},\"type\":\"public-key\"}"),
+            ("session_duration_minutes", 30),
+        ])
     }
 }
 

--- a/Tests/StytchCoreTests/PasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/PasswordsTestCase.swift
@@ -12,10 +12,10 @@ final class PasswordsTestCase: BaseTestCase {
         Current.timer = { _, _, _ in .init() }
         _ = try await StytchClient.passwords.create(parameters: passwordParams)
 
-        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords", method: .post, bodyContains: [
-            ("email", "user@stytch.com"),
-            ("session_duration_minutes", 26),
-            ("password", "password123"),
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords", method: .post, bodyEquals: [
+            "email": "user@stytch.com",
+            "session_duration_minutes": 26,
+            "password": "password123",
         ])
     }
 
@@ -26,10 +26,10 @@ final class PasswordsTestCase: BaseTestCase {
         Current.networkingClient = .mock(verifyingRequest: { request = $0 }, returning: .success(data))
         _ = try await StytchClient.passwords.authenticate(parameters: passwordParams)
 
-        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/authenticate", method: .post, bodyContains: [
-            ("email", "user@stytch.com"),
-            ("session_duration_minutes", 26),
-            ("password", "password123"),
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/authenticate", method: .post, bodyEquals: [
+            "email": "user@stytch.com",
+            "session_duration_minutes": 26,
+            "password": "password123",
         ])
     }
 
@@ -39,8 +39,8 @@ final class PasswordsTestCase: BaseTestCase {
         Current.networkingClient = .mock(verifyingRequest: { request = $0 }, returning: .success(data))
         _ = try await StytchClient.passwords.strengthCheck(parameters: StytchClient.Passwords.StrengthCheckParameters(email: nil, password: "p@ssword123"))
 
-        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/strength_check", method: .post, bodyContains: [
-            ("password", "p@ssword123"),
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/strength_check", method: .post, bodyEquals: [
+            "password": "p@ssword123",
         ])
     }
 
@@ -53,23 +53,23 @@ final class PasswordsTestCase: BaseTestCase {
         Current.networkingClient = .mock(verifyingRequest: { request = $0 }, returning: .success(startData), .success(finishData))
         _ = try await StytchClient.passwords.resetByEmailStart(parameters: .init(email: "user@stytch.com", loginUrl: nil, loginExpiration: nil, resetPasswordUrl: XCTUnwrap(URL(string: "https://stytch.com/reset")), resetPasswordExpiration: 15))
 
-        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/email/reset/start", method: .post, bodyContains: [
-            ("email", "user@stytch.com"),
-            ("reset_password_expiration_minutes", 15),
-            ("reset_password_redirect_url", "https://stytch.com/reset"),
-            ("code_challenge", "V9dLhNVhiUv_9m8cwFSzLGR9l-q6NAeLskiVZ7WsjA8"),
-            ("code_challenge_method", "S256"),
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/email/reset/start", method: .post, bodyEquals: [
+            "email": "user@stytch.com",
+            "reset_password_expiration_minutes": 15,
+            "reset_password_redirect_url": "https://stytch.com/reset",
+            "code_challenge": "V9dLhNVhiUv_9m8cwFSzLGR9l-q6NAeLskiVZ7WsjA8",
+            "code_challenge_method": "S256",
         ])
 
         Current.timer = { _, _, _ in .init() }
 
         _ = try await StytchClient.passwords.resetByEmail(parameters: .init(token: "12345", password: "iAMpasswordHEARmeROAR"))
 
-        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/email/reset", method: .post, bodyContains: [
-            ("token", "12345"),
-            ("code_verifier", "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741"),
-            ("session_duration_minutes", 30),
-            ("password", "iAMpasswordHEARmeROAR"),
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/email/reset", method: .post, bodyEquals: [
+            "token": "12345",
+            "code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
+            "session_duration_minutes": 30,
+            "password": "iAMpasswordHEARmeROAR",
         ])
     }
 }

--- a/Tests/StytchCoreTests/PasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/PasswordsTestCase.swift
@@ -12,9 +12,11 @@ final class PasswordsTestCase: BaseTestCase {
         Current.timer = { _, _, _ in .init() }
         _ = try await StytchClient.passwords.create(parameters: passwordParams)
 
-        XCTAssertEqual(request?.url?.absoluteString, "https://web.stytch.com/sdk/v1/passwords")
-        XCTAssertEqual(request?.httpMethod, "POST")
-        XCTAssertEqual(request?.httpBody, Data("{\"email\":\"user@stytch.com\",\"session_duration_minutes\":26,\"password\":\"password123\"}".utf8))
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords", method: .post, bodyContains: [
+            ("email", "user@stytch.com"),
+            ("session_duration_minutes", 26),
+            ("password", "password123"),
+        ])
     }
 
     func testAuthenticate() async throws {
@@ -24,9 +26,11 @@ final class PasswordsTestCase: BaseTestCase {
         Current.networkingClient = .mock(verifyingRequest: { request = $0 }, returning: .success(data))
         _ = try await StytchClient.passwords.authenticate(parameters: passwordParams)
 
-        XCTAssertEqual(request?.url?.absoluteString, "https://web.stytch.com/sdk/v1/passwords/authenticate")
-        XCTAssertEqual(request?.httpMethod, "POST")
-        XCTAssertEqual(request?.httpBody, Data("{\"email\":\"user@stytch.com\",\"session_duration_minutes\":26,\"password\":\"password123\"}".utf8))
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/authenticate", method: .post, bodyContains: [
+            ("email", "user@stytch.com"),
+            ("session_duration_minutes", 26),
+            ("password", "password123"),
+        ])
     }
 
     func testStrengthCheck() async throws {
@@ -35,9 +39,9 @@ final class PasswordsTestCase: BaseTestCase {
         Current.networkingClient = .mock(verifyingRequest: { request = $0 }, returning: .success(data))
         _ = try await StytchClient.passwords.strengthCheck(parameters: StytchClient.Passwords.StrengthCheckParameters(email: nil, password: "p@ssword123"))
 
-        XCTAssertEqual(request?.url?.absoluteString, "https://web.stytch.com/sdk/v1/passwords/strength_check")
-        XCTAssertEqual(request?.httpMethod, "POST")
-        XCTAssertEqual(request?.httpBody, Data("{\"password\":\"p@ssword123\"}".utf8))
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/strength_check", method: .post, bodyContains: [
+            ("password", "p@ssword123"),
+        ])
     }
 
     func testReset() async throws {
@@ -49,16 +53,23 @@ final class PasswordsTestCase: BaseTestCase {
         Current.networkingClient = .mock(verifyingRequest: { request = $0 }, returning: .success(startData), .success(finishData))
         _ = try await StytchClient.passwords.resetByEmailStart(parameters: .init(email: "user@stytch.com", loginUrl: nil, loginExpiration: nil, resetPasswordUrl: XCTUnwrap(URL(string: "https://stytch.com/reset")), resetPasswordExpiration: 15))
 
-        XCTAssertEqual(request?.url?.absoluteString, "https://web.stytch.com/sdk/v1/passwords/email/reset/start")
-        XCTAssertEqual(request?.httpMethod, "POST")
-        XCTAssertEqual(request?.httpBody, Data("{\"email\":\"user@stytch.com\",\"reset_password_redirect_url\":\"https:\\/\\/stytch.com\\/reset\",\"reset_password_expiration_minutes\":15,\"code_challenge\":\"V9dLhNVhiUv_9m8cwFSzLGR9l-q6NAeLskiVZ7WsjA8\",\"code_challenge_method\":\"S256\"}".utf8))
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/email/reset/start", method: .post, bodyContains: [
+            ("email", "user@stytch.com"),
+            ("reset_password_expiration_minutes", 15),
+            ("reset_password_redirect_url", "https://stytch.com/reset"),
+            ("code_challenge", "V9dLhNVhiUv_9m8cwFSzLGR9l-q6NAeLskiVZ7WsjA8"),
+            ("code_challenge_method", "S256"),
+        ])
 
         Current.timer = { _, _, _ in .init() }
 
         _ = try await StytchClient.passwords.resetByEmail(parameters: .init(token: "12345", password: "iAMpasswordHEARmeROAR"))
 
-        XCTAssertEqual(request?.url?.absoluteString, "https://web.stytch.com/sdk/v1/passwords/email/reset")
-        XCTAssertEqual(request?.httpMethod, "POST")
-        XCTAssertEqual(request?.httpBody, Data("{\"session_duration_minutes\":30,\"password\":\"iAMpasswordHEARmeROAR\",\"code_verifier\":\"e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741\",\"token\":\"12345\"}".utf8))
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/passwords/email/reset", method: .post, bodyContains: [
+            ("token", "12345"),
+            ("code_verifier", "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741"),
+            ("session_duration_minutes", 30),
+            ("password", "iAMpasswordHEARmeROAR"),
+        ])
     }
 }

--- a/Tests/StytchCoreTests/SessionsTestCase.swift
+++ b/Tests/StytchCoreTests/SessionsTestCase.swift
@@ -21,17 +21,11 @@ final class SessionsTestCase: BaseTestCase {
             hostUrl: try XCTUnwrap(URL(string: "https://url.com"))
         )
 
-        let response = try await StytchClient.sessions.authenticate(parameters: parameters)
+        _ = try await StytchClient.sessions.authenticate(parameters: parameters)
 
-        XCTAssertEqual(response.user.id, authResponse.user.id)
-        XCTAssertEqual(response.sessionToken, "hello_session")
-        XCTAssertEqual(response.sessionJwt, "jwt_for_me")
-        XCTAssertTrue(Calendar.current.isDate(response.session.expiresAt, equalTo: authResponse.session.expiresAt, toGranularity: .nanosecond))
-
-        // Verify request
-        XCTAssertEqual(request?.url?.absoluteString, "https://web.stytch.com/sdk/v1/sessions/authenticate")
-        XCTAssertEqual(request?.httpMethod, "POST")
-        XCTAssertEqual(request?.httpBody, Data("{\"session_duration_minutes\":15}".utf8))
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/sessions/authenticate", method: .post, bodyContains: [
+            ("session_duration_minutes", 15)
+        ])
 
         XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("jwt_for_me"))
         XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("hello_session"))
@@ -55,14 +49,9 @@ final class SessionsTestCase: BaseTestCase {
         XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("opaque_all_day"))
         XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("i'm_jwt"))
 
-        let response = try await StytchClient.sessions.revoke()
-        XCTAssertEqual(response.statusCode, 200)
-        XCTAssertEqual(response.requestId, "request_id")
+        _ = try await StytchClient.sessions.revoke()
 
-        // Verify request
-        XCTAssertEqual(request?.url?.absoluteString, "https://web.stytch.com/sdk/v1/sessions/revoke")
-        XCTAssertEqual(request?.httpMethod, "POST")
-        XCTAssertEqual(request?.httpBody, Data("{}".utf8))
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/sessions/revoke", method: .post, bodyContains: [])
 
         XCTAssertNil(StytchClient.sessions.sessionJwt)
         XCTAssertNil(StytchClient.sessions.sessionToken)

--- a/Tests/StytchCoreTests/SessionsTestCase.swift
+++ b/Tests/StytchCoreTests/SessionsTestCase.swift
@@ -23,9 +23,12 @@ final class SessionsTestCase: BaseTestCase {
 
         _ = try await StytchClient.sessions.authenticate(parameters: parameters)
 
-        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/sessions/authenticate", method: .post, bodyContains: [
-            ("session_duration_minutes", 15)
-        ])
+        try XCTAssertRequest(
+            request,
+            urlString: "https://web.stytch.com/sdk/v1/sessions/authenticate",
+            method: .post,
+            bodyEquals: ["session_duration_minutes": 15]
+        )
 
         XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("jwt_for_me"))
         XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("hello_session"))
@@ -51,7 +54,7 @@ final class SessionsTestCase: BaseTestCase {
 
         _ = try await StytchClient.sessions.revoke()
 
-        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/sessions/revoke", method: .post, bodyContains: [])
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/sessions/revoke", method: .post, bodyEquals: [:])
 
         XCTAssertNil(StytchClient.sessions.sessionJwt)
         XCTAssertNil(StytchClient.sessions.sessionToken)

--- a/Tests/StytchCoreTests/StytchClientTestCase.swift
+++ b/Tests/StytchCoreTests/StytchClientTestCase.swift
@@ -10,17 +10,11 @@ final class StytchClientTestCase: BaseTestCase {
         StytchClient.configure(publicToken: "xyz", hostUrl: try XCTUnwrap(URL(string: "https://myapp.com")))
         let response: String? = try await StytchClient.router.get(route: .sessions(.authenticate))
 
-        // Verify request
-        XCTAssertEqual(request?.url?.absoluteString, "https://web.stytch.com/sdk/v1/sessions/authenticate")
-        XCTAssertEqual(request?.httpMethod, "GET")
-        XCTAssertEqual(
-            request?.allHTTPHeaderFields,
-            [
-                "Content-Type": "application/json",
-                "X-SDK-Client": try Current.clientInfo.base64EncodedString(),
-                "Authorization": "Basic eHl6Onh5eg==",
-            ]
-        )
+        try XCTAssertRequest(request, urlString: "https://web.stytch.com/sdk/v1/sessions/authenticate", method: .get, headersEqual: [
+            "Content-Type": "application/json",
+            "X-SDK-Client": try Current.clientInfo.base64EncodedString(),
+            "Authorization": "Basic eHl6Onh5eg==",
+        ])
 
         XCTAssertEqual(response, "Hello, World!")
     }

--- a/Tests/StytchCoreTests/XCTestHelpers.swift
+++ b/Tests/StytchCoreTests/XCTestHelpers.swift
@@ -20,18 +20,31 @@ func XCTAssertRequest(
     _ request: URLRequest?,
     urlString: String,
     method: XCTHTTPMethod,
-    bodyContains: [(key: String, value: JSON)] = [],
+    bodyContains: [(key: String, value: JSON)]? = nil,
+    headersEqual expectedHeaders: [String: String]? = nil,
     line: UInt = #line,
     file: StaticString = #file
 ) throws {
-    guard let request = request else { return }
+    let request = try XCTUnwrap(request)
     XCTAssertEqual(request.url?.absoluteString, urlString, file: file, line: line)
     XCTAssertEqual(request.httpMethod, method.rawValue, file: file, line: line)
-    if !bodyContains.isEmpty {
+    if let bodyContains = bodyContains {
         let bodyJSON = try JSONDecoder().decode(JSON.self, from: XCTUnwrap(request.httpBody))
-        bodyContains.forEach { content in
-            XCTAssertEqual(bodyJSON[content.key], content.value, file: file, line: line)
+        if bodyContains.isEmpty {
+            XCTAssertEqual(bodyJSON, [])
+        } else {
+            bodyContains.forEach { content in
+                XCTAssertEqual(
+                    content.key.components(separatedBy: ".").reduce(bodyJSON) { $0?[$1] },
+                    content.value,
+                    file: file,
+                    line: line
+                )
+            }
         }
+    }
+    if let expectedHeaders = expectedHeaders {
+        XCTAssertEqual(request.allHTTPHeaderFields, expectedHeaders)
     }
 }
 

--- a/Tests/StytchCoreTests/XCTestHelpers.swift
+++ b/Tests/StytchCoreTests/XCTestHelpers.swift
@@ -20,7 +20,7 @@ func XCTAssertRequest(
     _ request: URLRequest?,
     urlString: String,
     method: XCTHTTPMethod,
-    bodyContains: [(key: String, value: JSON)]? = nil,
+    bodyEquals expectedBody: JSON? = nil,
     headersEqual expectedHeaders: [String: String]? = nil,
     line: UInt = #line,
     file: StaticString = #file
@@ -28,20 +28,9 @@ func XCTAssertRequest(
     let request = try XCTUnwrap(request)
     XCTAssertEqual(request.url?.absoluteString, urlString, file: file, line: line)
     XCTAssertEqual(request.httpMethod, method.rawValue, file: file, line: line)
-    if let bodyContains = bodyContains {
+    if let expectedBody = expectedBody {
         let bodyJSON = try JSONDecoder().decode(JSON.self, from: XCTUnwrap(request.httpBody))
-        if bodyContains.isEmpty {
-            XCTAssertEqual(bodyJSON, [])
-        } else {
-            bodyContains.forEach { content in
-                XCTAssertEqual(
-                    content.key.components(separatedBy: ".").reduce(bodyJSON) { $0?[$1] },
-                    content.value,
-                    file: file,
-                    line: line
-                )
-            }
-        }
+        XCTAssertEqual(bodyJSON, expectedBody)
     }
     if let expectedHeaders = expectedHeaders {
         XCTAssertEqual(request.allHTTPHeaderFields, expectedHeaders)


### PR DESCRIPTION
Migrate old tests to use new XCTAssertRequest helper and enable/require body equality