### PR TITLE
[fix] Fix dotenv Script/demo dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,7 @@ jobs:
     - name: Codegen
       run: |
         make codegen
-        if [[ ! -z $(git status --porcelain | grep -v Brewfile.lock.json) ]]; then
-          git status --porcelain
+        if [[ ! -z $(git status --porcelain | grep -v 'Brewfile.lock.json\|Gemfile.lock') ]]; then
           echo 'Codegen produced uncommitted changes. Commit changes and re-push.'
           exit 1
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         make codegen
         if [[ ! -z $(git status --porcelain | grep -v Brewfile.lock.json) ]]; then
+          git status --porcelain
           echo 'Codegen produced uncommitted changes. Commit changes and re-push.'
           exit 1
         fi

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ source "https://rubygems.org"
 
 gem 'aws-sdk-s3'
 gem 'cocoapods'
+gem 'dotenv'
 gem 'xcpretty'

--- a/Scripts/demo
+++ b/Scripts/demo
@@ -1,7 +1,5 @@
 #! /usr/bin/env ruby
 
-require 'dotenv'
-
 class String
   # colorization
   def colorize(color_code)
@@ -111,6 +109,7 @@ class Runner
   end
 
   def load_env
+    require 'dotenv'
     Dotenv.load(File.join(demo_root, '.env'))
   end
 


### PR DESCRIPTION
* Add `dotenv` to Gemfile
* Only require dotenv when loading env so `setup` can be called before dotenv is installed

[Linear ticket](https://linear.app/stytch/issue/SDK-657/%5Bios-sdk-demo%5D-missing-dotenv-gem-after-running-make-demo)