### PR TITLE
[platform] Improve ci execution time

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -2,12 +2,6 @@ name: Bootstrap
 on:
   workflow_call:
 
-inputs:
-  checkout-path:
-    description: “Username for image registry”
-    required: false
-    default: ''
-
 runs:
   using: composite
   steps:
@@ -28,5 +22,5 @@ runs:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALL_CLEANUP: 1
       run: |
-        make setup # NOTE: - CI won't run bundle install
+        NO_BUNDLE=1 make setup
         make tools

--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -2,12 +2,19 @@ name: Bootstrap
 on:
   workflow_call:
 
-env:
-  DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+inputs:
+  checkout-path:
+    description: “Username for image registry”
+    required: false
+    default: ''
 
 runs:
   using: composite
   steps:
+    - uses: actions/checkout@v3
+      with:
+        path: ${{ inputs.checkout-path }}
+
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: .ruby-version
@@ -27,30 +34,3 @@ runs:
       run: |
         make setup # NOTE: - CI won't run bundle install
         make tools
-
-# name: "Publish to Docker"
-# description: "Pushes built artifacts to Docker"
-
-# inputs:
-#   registry_username:
-#     description: “Username for image registry”
-#     required: true
-#   registry_password:
-#     description: “Password for image registry”
-#     required: true
-
-# runs:
-#   using: "composite"
-#   steps:
-#       - uses: docker/setup-buildx-action@v1
-
-#       - uses: docker/login-action@v1
-#         with:
-#           username: ${{inputs.registry_username}}
-#           password: ${{inputs.registry_password}}
-
-#       - uses: docker/build-push-action@v2
-#         with:
-#           context: .
-#           push: true
-#           tags: user/app:latest

--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -14,13 +14,13 @@ runs:
         bundler-cache: true
 
     - name: Cache Mint
-      id: cache-mint
       uses: actions/cache@v3
       with:
         path: ~/.mint
         key: ${{ runner.os }}-mint-v1-${{ hashFiles('Mintfile') }}
 
     - name: Bootstrap
+      shell: bash
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -1,0 +1,56 @@
+name: Bootstrap
+on:
+  workflow_call:
+
+env:
+  DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+
+runs:
+  using: composite
+  steps:
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: .ruby-version
+        bundler-cache: true
+
+    - name: Cache Mint
+      id: cache-mint
+      uses: actions/cache@v3
+      with:
+        path: ~/.mint
+        key: ${{ runner.os }}-mint-v1-${{ hashFiles('Mintfile') }}
+
+    - name: Bootstrap
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
+      run: |
+        make setup # NOTE: - CI won't run bundle install
+        make tools
+
+# name: "Publish to Docker"
+# description: "Pushes built artifacts to Docker"
+
+# inputs:
+#   registry_username:
+#     description: “Username for image registry”
+#     required: true
+#   registry_password:
+#     description: “Password for image registry”
+#     required: true
+
+# runs:
+#   using: "composite"
+#   steps:
+#       - uses: docker/setup-buildx-action@v1
+
+#       - uses: docker/login-action@v1
+#         with:
+#           username: ${{inputs.registry_username}}
+#           password: ${{inputs.registry_password}}
+
+#       - uses: docker/build-push-action@v2
+#         with:
+#           context: .
+#           push: true
+#           tags: user/app:latest

--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -11,10 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
-      with:
-        path: ${{ inputs.checkout-path }}
-
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: .ruby-version

--- a/.github/workflows/cut_version.yml
+++ b/.github/workflows/cut_version.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   cut-version:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
 
     steps:
 

--- a/.github/workflows/cut_version.yml
+++ b/.github/workflows/cut_version.yml
@@ -10,10 +10,12 @@ on:
           - major
           - minor
 
+env:
+  DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+
 jobs:
   cut-version:
-
-    runs-on: [ self-hosted, apple-silicon ]
+    runs-on: macos-12
 
     steps:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,36 +16,15 @@ jobs:
     runs-on: macos-12
 
     steps:
-
-    - uses: actions/checkout@v3
+    - name: Bootstrap
+      uses: ./.github/actions/bootstrap
       with:
-        path: main
+        checkout-path: main
 
     - uses: actions/checkout@v3
       with:
         ref: docs/live
         path: docs-live
-
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: .ruby-version
-        bundler-cache: true
-
-    - name: Cache Mint
-      id: cache-mint
-      uses: actions/cache@v3
-      with:
-        path: ~/.mint
-        key: ${{ runner.os }}-mint-v1-${{ hashFiles('Mintfile') }}
-
-    - name: Bootstrap
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_NO_INSTALL_CLEANUP: 1
-      working-directory: main
-      run: |
-        make setup
-        make tools
 
     - name: Codegen
       working-directory: main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,13 +4,16 @@ on:
     branches:
       - main
 
+env:
+  DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull') }}
 
 jobs:
   docs:
-    runs-on: [ self-hosted, apple-silicon ]
+    runs-on: macos-12
 
     steps:
 
@@ -23,7 +26,22 @@ jobs:
         ref: docs/live
         path: docs-live
 
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: .ruby-version
+        bundler-cache: true
+
+    - name: Cache Mint
+      id: cache-mint
+      uses: actions/cache@v3
+      with:
+        path: ~/.mint
+        key: ${{ runner.os }}-mint-v1-${{ hashFiles('Mintfile') }}
+
     - name: Bootstrap
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
       working-directory: main
       run: |
         make setup

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,15 +16,17 @@ jobs:
     runs-on: macos-12
 
     steps:
-    - name: Bootstrap
-      uses: ./.github/actions/bootstrap
+    - uses: actions/checkout@v3
       with:
-        checkout-path: main
+        path: main
 
     - uses: actions/checkout@v3
       with:
         ref: docs/live
         path: docs-live
+
+    - name: Bootstrap
+      uses: ./.github/actions/bootstrap
 
     - name: Codegen
       working-directory: main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,12 @@ on:
   release:
     types: [published]
 
+env:
+  DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+
 jobs:
   release:
-    runs-on: [ self-hosted, apple-silicon ]
+    runs-on: macos-12
 
     steps:
 
@@ -15,9 +18,7 @@ jobs:
         ref: ${{ github.event.release.tag_name }}
 
     - name: Bootstrap
-      run: |
-        make setup
-        make tools
+      uses: ./.github/actions/bootstrap
 
     - name: Publish to Cocoapods
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,22 +7,23 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+env:
+  DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull') }}
 
 jobs:
   release:
-    runs-on: [ self-hosted, apple-silicon ]
+    runs-on: macos-12
 
     steps:
 
     - uses: actions/checkout@v3
 
     - name: Bootstrap
-      run: |
-        make setup
-        make tools
+      uses: ./.github/actions/bootstrap
 
     - name: Ensure SDK version matches current tag
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - id: set-matrix
         run: |
           matrixvalues='{"test-os":"ios"},{"test-os":"macos"},{"test-os":"tvos"}'
-          if [[ ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test-watchos') }} ]]; then
+          if [[ $(${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test-watchos') }}) ]]; then
             matrixvalues+=',{"test-os":"watchos"}'
           fi
           echo "matrix={\"include\":[${matrixvalues}]}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,13 +29,12 @@ jobs:
         run: |
           matrix_values='{"test-os":"ios"},{"test-os":"macos"},{"test-os":"tvos"}'
           has_watchos_pr_label() {
-            if [[ $(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep 'test-watchos') ]]; then echo '1'; fi
+            if [[ ${{ github.event.pull_request.number }} && $(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep 'test-watchos') ]]; then echo '1'; fi
           }
-          # [[ ${{ github.event.pull_request.number }} ]]
           if [[ $(${{ github.ref == 'refs/heads/main' }}) || $(has_watchos_pr_label) ]]; then
-          # if [[ || contains(github.event.pull_request.labels.*.name, 'test-watchos') }}) ]]; then
             matrix_values+=',{"test-os":"watchos"}'
           fi
+          echo $matrix_values
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - uses: .github/workflows/bootstrap.yml
+    - uses: ./.github/workflows/bootstrap.yml
 
     - name: Codegen
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           matrix_values='{"test-os":"ios"},{"test-os":"macos"},{"test-os":"tvos"}'
           has_watchos_pr_label() {
-            if [[ gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep 'test-watchos' ]]; then echo '1'; fi
+            if [[ $(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep 'test-watchos') ]]; then echo '1'; fi
           }
           # [[ ${{ github.event.pull_request.number }} ]]
           if [[ $(${{ github.ref == 'refs/heads/main' }}) || $(has_watchos_pr_label) ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
       - id: set-matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           matrix_values='{"test-os":"ios"},{"test-os":"macos"},{"test-os":"tvos"}'
           has_watchos_pr_label() {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,11 @@ concurrency:
 
 jobs:
   test:
+    runs-on: macos-12
+
     strategy:
       matrix:
         test-os: [ios, tvos, watchos, macos]
-
-    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,39 +27,39 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: .ruby-version
-        bundler-cache: true
+    # - uses: ruby/setup-ruby@v1
+    #   with:
+    #     ruby-version: .ruby-version
+    #     bundler-cache: true
 
-    - name: Cache Mint
-      id: cache-mint
-      uses: actions/cache@v3
-      with:
-        path: ~/.mint
-        key: ${{ runner.os }}-mint-v1-${{ hashFiles('Mintfile') }}
+    # - name: Cache Mint
+    #   id: cache-mint
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: ~/.mint
+    #     key: ${{ runner.os }}-mint-v1-${{ hashFiles('Mintfile') }}
 
-    - name: Bootstrap
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_NO_INSTALL_CLEANUP: 1
-      run: |
-        make setup # NOTE: - CI won't run bundle install
-        make tools
+    # - name: Bootstrap
+    #   env:
+    #     HOMEBREW_NO_AUTO_UPDATE: 1
+    #     HOMEBREW_NO_INSTALL_CLEANUP: 1
+    #   run: |
+    #     make setup # NOTE: - CI won't run bundle install
+    #     make tools
 
-    - name: Codegen
-      run: |
-        make codegen
-        if [[ ! -z $(git status --porcelain | grep -Ev 'Brewfile.lock.json|Gemfile.lock') ]]; then
-          echo 'Codegen produced uncommitted changes. Commit changes and re-push.'
-          exit 1
-        fi
+    # - name: Codegen
+    #   run: |
+    #     make codegen
+    #     if [[ ! -z $(git status --porcelain | grep -Ev 'Brewfile.lock.json|Gemfile.lock') ]]; then
+    #       echo 'Codegen produced uncommitted changes. Commit changes and re-push.'
+    #       exit 1
+    #     fi
 
-    - name: Lint
-      run: make lint
+    # - name: Lint
+    #   run: make lint
 
-    - name: Test
-      run: make test-${{ matrix.test-os }}
+    # - name: Test
+    #   run: make test-${{ matrix.test-os }}
 
     - name: Coverage
       if: matrix.test-os == 'macos'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - uses: stytchauth/stytch-swift/.github/workflows/bootstrap.yml
+    - uses: .github/workflows/bootstrap.yml
 
     - name: Codegen
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       run: make test-${{ matrix.test-os }}
 
     - name: Coverage
-      if: ${{ matrix.test-os }} == 'macos'
+      if: matrix.test-os == 'macos'
       run: |
         make coverage
         Scripts/generate-coverage-summary .coverage/lcov.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
       run: make lint
 
     - name: Test
+      if: matrix.test-os != 'watchos' || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test-watchos')
       run: make test-${{ matrix.test-os }}
 
     - name: Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         Scripts/generate-coverage-summary .coverage/lcov.json >> $GITHUB_STEP_SUMMARY
 
     - uses: actions/upload-artifact@v3
-      if: ${{ matrix.test-os }} == 'macos'
+      if: matrix.test-os == 'macos'
       with:
         name: Coverage
         path: .coverage/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,11 @@ jobs:
       - id: set-matrix
         run: |
           matrix_values='{"test-os":"ios"},{"test-os":"macos"},{"test-os":"tvos"}'
-# [[ ${{ github.event.pull_request.number }} ]]
-          has_watchos_pr_label={ if [[ gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep 'test-watchos' ]]; then echo '1'; fi }()
-          if [[ $(${{ github.ref == 'refs/heads/main' }}) ]] || [[ $(has_watchos_pr_label) ]]; then
+          has_watchos_pr_label() {
+            if [[ gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep 'test-watchos' ]]; then echo '1'; fi
+          }
+          # [[ ${{ github.event.pull_request.number }} ]]
+          if [[ $(${{ github.ref == 'refs/heads/main' }}) || $(has_watchos_pr_label) ]]; then
           # if [[ || contains(github.event.pull_request.labels.*.name, 'test-watchos') }}) ]]; then
             matrix_values+=',{"test-os":"watchos"}'
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,8 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v3
-
-    - uses: ./.github/actions/bootstrap
+    - name: Bootstrap
+      uses: ./.github/actions/bootstrap
 
     - name: Codegen
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: Test
+
 on:
   push:
     branches:
@@ -23,6 +24,7 @@ jobs:
     runs-on: macos-12
 
     steps:
+    - uses: actions/checkout@v3
 
     - name: Bootstrap
       uses: ./.github/actions/bootstrap

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,39 +27,39 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    # - uses: ruby/setup-ruby@v1
-    #   with:
-    #     ruby-version: .ruby-version
-    #     bundler-cache: true
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: .ruby-version
+        bundler-cache: true
 
-    # - name: Cache Mint
-    #   id: cache-mint
-    #   uses: actions/cache@v3
-    #   with:
-    #     path: ~/.mint
-    #     key: ${{ runner.os }}-mint-v1-${{ hashFiles('Mintfile') }}
+    - name: Cache Mint
+      id: cache-mint
+      uses: actions/cache@v3
+      with:
+        path: ~/.mint
+        key: ${{ runner.os }}-mint-v1-${{ hashFiles('Mintfile') }}
 
-    # - name: Bootstrap
-    #   env:
-    #     HOMEBREW_NO_AUTO_UPDATE: 1
-    #     HOMEBREW_NO_INSTALL_CLEANUP: 1
-    #   run: |
-    #     make setup # NOTE: - CI won't run bundle install
-    #     make tools
+    - name: Bootstrap
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
+      run: |
+        make setup # NOTE: - CI won't run bundle install
+        make tools
 
-    # - name: Codegen
-    #   run: |
-    #     make codegen
-    #     if [[ ! -z $(git status --porcelain | grep -Ev 'Brewfile.lock.json|Gemfile.lock') ]]; then
-    #       echo 'Codegen produced uncommitted changes. Commit changes and re-push.'
-    #       exit 1
-    #     fi
+    - name: Codegen
+      run: |
+        make codegen
+        if [[ ! -z $(git status --porcelain | grep -Ev 'Brewfile.lock.json|Gemfile.lock') ]]; then
+          echo 'Codegen produced uncommitted changes. Commit changes and re-push.'
+          exit 1
+        fi
 
-    # - name: Lint
-    #   run: make lint
+    - name: Lint
+      run: make lint
 
-    # - name: Test
-    #   run: make test-${{ matrix.test-os }}
+    - name: Test
+      run: make test-${{ matrix.test-os }}
 
     - name: Coverage
       if: matrix.test-os == 'macos'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - id: set-matrix
         run: |
           matrixvalues='{"test-os":"ios"},{"test-os":"macos"},{"test-os":"tvos"}'
-          if [[ ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test-watchos') }}]]; then
+          if [[ ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test-watchos') }} ]]; then
             matrixvalues+=',{"test-os":"watchos"}'
           fi
           echo "matrix={\"include\":[${matrixvalues}]}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,14 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          matrixvalues='{"test-os":"ios"},{"test-os":"macos"},{"test-os":"tvos"}'
-          if [[ $(${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test-watchos') }}) ]]; then
-            matrixvalues+=',{"test-os":"watchos"}'
+          matrix_values='{"test-os":"ios"},{"test-os":"macos"},{"test-os":"tvos"}'
+# [[ ${{ github.event.pull_request.number }} ]]
+          has_watchos_pr_label={ if [[ gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep 'test-watchos' ]]; then echo '1'; fi }()
+          if [[ $(${{ github.ref == 'refs/heads/main' }}) ]] || [[ $(has_watchos_pr_label) ]]; then
+          # if [[ || contains(github.event.pull_request.labels.*.name, 'test-watchos') }}) ]]; then
+            matrix_values+=',{"test-os":"watchos"}'
           fi
-          echo "matrix={\"include\":[${matrixvalues}]}" >> $GITHUB_OUTPUT
+          echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
 
   test:
     runs-on: macos-12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull') }}
 
 jobs:
-
   test:
     strategy:
       matrix:
@@ -27,25 +26,7 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: .ruby-version
-        bundler-cache: true
-
-    - name: Cache Mint
-      id: cache-mint
-      uses: actions/cache@v3
-      with:
-        path: ~/.mint
-        key: ${{ runner.os }}-mint-v1-${{ hashFiles('Mintfile') }}
-
-    - name: Bootstrap
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_NO_INSTALL_CLEANUP: 1
-      run: |
-        make setup # NOTE: - CI won't run bundle install
-        make tools
+    - uses: stytchauth/stytch-swift/.github/workflows/bootstrap.yml
 
     - name: Codegen
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ concurrency:
 jobs:
 
   test:
+    strategy:
+      matrix:
+        test-os: [ios, tvos, watchos, macos]
+
     runs-on: macos-12
 
     steps:
@@ -54,24 +58,17 @@ jobs:
     - name: Lint
       run: make lint
 
-    - name: Test iOS
-      run: make test-ios
-
-    - name: Test tvOS
-      run: make test-tvos
-
-    - name: Test watchOS
-      run: make test-watchos
-
-    - name: Test macOS
-      run: make test-macos
+    - name: Test
+      run: make test-${{ matrix.test-os }}
 
     - name: Coverage
+      if: ${{ test-os }} == 'macos'
       run: |
         make coverage
         Scripts/generate-coverage-summary .coverage/lcov.json >> $GITHUB_STEP_SUMMARY
 
     - uses: actions/upload-artifact@v3
+      if: ${{ test-os }} == 'macos'
       with:
         name: Coverage
         path: .coverage/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,11 @@ jobs:
         run: |
           matrix_values='{"test-os":"ios"},{"test-os":"macos"},{"test-os":"tvos"}'
           has_watchos_pr_label() {
-            if [[ ${{ github.event.pull_request.number }} && $(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep 'test-watchos') ]]; then echo '1'; fi
+            if [[ ${{ github.event.pull_request.number }} && $(gh pr view ${{ github.event.pull_request.url }} --json labels --jq '.labels[].name' | grep 'test-watchos') ]]; then echo '1'; fi
           }
           if [[ $(${{ github.ref == 'refs/heads/main' }}) || $(has_watchos_pr_label) ]]; then
             matrix_values+=',{"test-os":"watchos"}'
           fi
-          echo $matrix_values
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - uses: ./.github/workflows/bootstrap.yml
+    - uses: ./.github/actions/bootstrap
 
     - name: Codegen
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,15 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
     steps:
+      - uses: actions/checkout@v3
+
       - id: set-matrix
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           matrix_values='{"test-os":"ios"},{"test-os":"macos"},{"test-os":"tvos"}'
           has_watchos_pr_label() {
-            if [[ ${{ github.event.pull_request.number }} && $(gh pr view ${{ github.event.pull_request.url }} --json labels --jq '.labels[].name' | grep 'test-watchos') ]]; then echo '1'; fi
+            if [[ ${{ github.event.pull_request.number }} && $(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep 'test-watchos') ]]; then echo '1'; fi
           }
           if [[ $(${{ github.ref == 'refs/heads/main' }}) || $(has_watchos_pr_label) ]]; then
             matrix_values+=',{"test-os":"watchos"}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,14 +16,31 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull') }}
 
 jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+      - id: set-matrix
+        run: |
+          matrix-values="{\"test-os\":\"ios\"},{\"test-os\":\"macos\"},{\"test-os\":\"tvos\"}"
+          if [[ ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test-watchos') }}]]; then
+            matrix-values+=",{\"test-os\":\"watchos\"}"
+          fi
+          echo "matrix={\"include\":[${matrix-values}]}" >> $GITHUB_OUTPUT
+
   test:
     runs-on: macos-12
 
+    needs: set-matrix
+
     strategy:
-      matrix:
-        test-os: [ios, tvos, watchos, macos]
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
 
     steps:
+
     - uses: actions/checkout@v3
 
     - name: Bootstrap
@@ -41,7 +58,6 @@ jobs:
       run: make lint
 
     - name: Test
-      if: matrix.test-os != 'watchos' || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test-watchos')
       run: make test-${{ matrix.test-os }}
 
     - name: Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          matrix-values="{\"test-os\":\"ios\"},{\"test-os\":\"macos\"},{\"test-os\":\"tvos\"}"
+          matrixvalues='{"test-os":"ios"},{"test-os":"macos"},{"test-os":"tvos"}'
           if [[ ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test-watchos') }}]]; then
-            matrix-values+=",{\"test-os\":\"watchos\"}"
+            matrixvalues+=',{"test-os":"watchos"}'
           fi
-          echo "matrix={\"include\":[${matrix-values}]}" >> $GITHUB_OUTPUT
+          echo "matrix={\"include\":[${matrixvalues}]}" >> $GITHUB_OUTPUT
 
   test:
     runs-on: macos-12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,13 +62,13 @@ jobs:
       run: make test-${{ matrix.test-os }}
 
     - name: Coverage
-      if: ${{ test-os }} == 'macos'
+      if: ${{ matrix.test-os }} == 'macos'
       run: |
         make coverage
         Scripts/generate-coverage-summary .coverage/lcov.json >> $GITHUB_STEP_SUMMARY
 
     - uses: actions/upload-artifact@v3
-      if: ${{ test-os }} == 'macos'
+      if: ${{ matrix.test-os }} == 'macos'
       with:
         name: Coverage
         path: .coverage/

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -153,7 +153,7 @@
       "ventura": {
         "HOMEBREW_VERSION": "3.6.16",
         "HOMEBREW_PREFIX": "/opt/homebrew",
-        "Homebrew/homebrew-core": "b64980f6dfd8394eab4af06f5c3bb7d4ec2141e9",
+        "Homebrew/homebrew-core": "ec8774e9a9996e8984c1aeced7a29560dda284ce",
         "CLT": "14.2.0.0.1.1668646533",
         "Xcode": "14.0",
         "macOS": "13.1"

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint:
 
 setup:
 	$(ARCH) brew bundle
-	@if [ ! $(IS_CI) ]; then $(ARCH) bundle install; fi
+	@if [ ! $$NO_BUNDLE ]; then $(ARCH) bundle install; fi
 
 test-all: codegen
 	$(MAKE) test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 IOS_VERSION := $(shell xcodebuild -showsdks | grep iphoneos | sed 's/\(.*iphoneos\)\(.*\)/\2/')
 WATCHOS_VERSION := $(shell xcodebuild -showsdks | grep watchos | sed 's/\(.*watchos\)\(.*\)/\2/')
-TEST=xcodebuild test -disableAutomaticPackageResolution -skipPackageUpdates -project StytchDemo/StytchDemo.xcodeproj -scheme StytchCoreTests -sdk
+TEST=xcodebuild test -disableAutomaticPackageResolution -skipPackageUpdates -scheme Stytch -sdk
 
 IS_CI=$(shell [ ! -z "$$CI" ] && echo "1")
 ARCH=arch -$(shell [ $(IS_CI) ] && echo "x86_64" || echo "arm64e")

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 IOS_VERSION := $(shell xcodebuild -showsdks | grep iphoneos | sed 's/\(.*iphoneos\)\(.*\)/\2/')
 WATCHOS_VERSION := $(shell xcodebuild -showsdks | grep watchos | sed 's/\(.*watchos\)\(.*\)/\2/')
-TEST=xcodebuild test -disableAutomaticPackageResolution -skipPackageUpdates -scheme Stytch -sdk
 
 IS_CI=$(shell [ ! -z "$$CI" ] && echo "1")
 ARCH=arch -$(shell [ $(IS_CI) ] && echo "x86_64" || echo "arm64e")
 PIPEFAIL=set -o pipefail
 XCPRETTY=bundle exec xcpretty
+TEST=$(PIPEFAIL) && $(ARCH) xcodebuild test -disableAutomaticPackageResolution -skipPackageUpdates -scheme Stytch -sdk
 
 .PHONY: coverage codegen docs format lint setup test tests test-ios test-macos test-tvos test-watchos tools
 
@@ -48,13 +48,13 @@ test tests test-macos: codegen
 	$(ARCH) swift test --enable-code-coverage --disable-automatic-resolution --skip-update
 
 test-ios: codegen
-	$(PIPEFAIL) && $(ARCH) $(TEST) iphonesimulator$(IOS_VERSION) -destination "OS=$(IOS_VERSION),name=iPhone 14 Pro" | $(XCPRETTY)
+	$(TEST) iphonesimulator$(IOS_VERSION) -destination "OS=$(IOS_VERSION),name=iPhone 14 Pro"
 
 test-tvos: codegen
-	$(PIPEFAIL) && $(ARCH) $(TEST) appletvsimulator$(IOS_VERSION) -destination "OS=$(IOS_VERSION),name=Apple TV" | $(XCPRETTY)
+	$(TEST) appletvsimulator$(IOS_VERSION) -destination "OS=$(IOS_VERSION),name=Apple TV"
 
 test-watchos: codegen
-	$(PIPEFAIL) && $(ARCH) $(TEST) watchsimulator$(WATCHOS_VERSION) -destination "OS=$(WATCHOS_VERSION),name=Apple Watch Ultra (49mm)" | $(XCPRETTY)
+	$(TEST) watchsimulator$(WATCHOS_VERSION) -destination "OS=$(WATCHOS_VERSION),name=Apple Watch Ultra (49mm)"
 
 tools:
 	$(ARCH) mint bootstrap

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lint:
 	$(ARCH) mint run swiftformat --lint .
 
 setup:
-	$(ARCH) brew bundle
+	$(ARCH) brew install gh lcov mint
 	@if [ ! $(IS_CI) ]; then $(ARCH) bundle install; fi
 
 test-all: codegen

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ IOS_VERSION := $(shell xcodebuild -showsdks | grep iphoneos | sed 's/\(.*iphoneo
 WATCHOS_VERSION := $(shell xcodebuild -showsdks | grep watchos | sed 's/\(.*watchos\)\(.*\)/\2/')
 
 IS_CI=$(shell [ ! -z "$$CI" ] && echo "1")
-ARCH=arch -$(shell [ $(IS_CI) ] && echo "x86_64" || echo "arm64e")
+ARCH=arch -$(shell [ $(IS_CI) ] && echo "x86_64" || echo "arm64")
 PIPEFAIL=set -o pipefail
 XCPRETTY=bundle exec xcpretty
-TEST=$(PIPEFAIL) && $(ARCH) xcodebuild test -disableAutomaticPackageResolution -skipPackageUpdates -scheme Stytch -sdk
+TEST=$(PIPEFAIL) && $(ARCH) xcodebuild test -disableAutomaticPackageResolution -skipPackageUpdates -project StytchDemo/StytchDemo.xcodeproj -scheme StytchCoreTests -sdk
 
 .PHONY: coverage codegen docs format lint setup test tests test-ios test-macos test-tvos test-watchos tools
 
@@ -48,13 +48,13 @@ test tests test-macos: codegen
 	$(ARCH) swift test --enable-code-coverage --disable-automatic-resolution --skip-update
 
 test-ios: codegen
-	$(TEST) iphonesimulator$(IOS_VERSION) -destination "OS=$(IOS_VERSION),name=iPhone 14 Pro"
+	$(TEST) iphonesimulator$(IOS_VERSION) -destination "OS=$(IOS_VERSION),name=iPhone 14 Pro" | $(XCPRETTY)
 
 test-tvos: codegen
-	$(TEST) appletvsimulator$(IOS_VERSION) -destination "OS=$(IOS_VERSION),name=Apple TV"
+	$(TEST) appletvsimulator$(IOS_VERSION) -destination "OS=$(IOS_VERSION),name=Apple TV" | $(XCPRETTY)
 
 test-watchos: codegen
-	$(TEST) watchsimulator$(WATCHOS_VERSION) -destination "OS=$(WATCHOS_VERSION),name=Apple Watch Ultra (49mm)"
+	$(TEST) watchsimulator$(WATCHOS_VERSION) -destination "OS=$(WATCHOS_VERSION),name=Apple Watch Ultra (49mm)" | $(XCPRETTY)
 
 tools:
 	$(ARCH) mint bootstrap

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lint:
 	$(ARCH) mint run swiftformat --lint .
 
 setup:
-	$(ARCH) brew install gh lcov mint
+	$(ARCH) brew bundle
 	@if [ ! $(IS_CI) ]; then $(ARCH) bundle install; fi
 
 test-all: codegen


### PR DESCRIPTION
- Extracts `Bootstrap` commands to reusable action
- Parallelizes test execution on all platforms
- Runs watchOS tests only when there is a `test-watchos` label or when tests are run on the main branch