### PR TITLE
[platform] Fix and improve release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Create XCFramework
       run: |
-        arch -arm64 mint run swift-create-xcframework --zip --xc-setting SKIP_INSTALL=NO --xc-setting BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+        make xc-framework
         mv StytchCore.zip StytchCore.xcframework.zip
 
     - name: Build docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
 
     - name: Publish to GitHub
       if: startsWith(github.ref, 'refs/tags/')
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh release create \
           ${{ github.ref_name }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,11 @@ jobs:
         zip -r StytchCore.doccarchive.zip StytchCore.doccarchive
 
     - name: Publish to GitHub
-      uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
-      with:
-        draft: true # Should be edited and published manually to trigger cocoapods/carthage updates, if changed here, must change "types: [created]" for Publish workflow
-        files: |
-          StytchCore.xcframework.zip
-          .build/Build/Products/Release-iphoneos/StytchCore.doccarchive.zip
-        generate_release_notes: true
-
+      run: |
+        gh release create \
+          ${{ github.ref_name }} \
+          StytchCore.xcframework.zip \
+          ./build/Build/Products/Release-iphoneos/StytchCore.doccarchive.zip \
+          --draft \ # Should be edited and published manually to trigger cocoapods/carthage updates, if changed here, must change "types: [created]" for Publish workflow
+          --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,10 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        # Release should be edited and published manually to trigger cocoapods/carthage updates. If --draft removed, must change "types: [created]" for Publish workflow
         gh release create \
           ${{ github.ref_name }} \
           StytchCore.xcframework.zip \
           ./build/Build/Products/Release-iphoneos/StytchCore.doccarchive.zip \
-          --draft \ # Should be edited and published manually to trigger cocoapods/carthage updates, if changed here, must change "types: [created]" for Publish workflow
+          --draft \
           --generate-notes

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,6 @@ test-watchos: codegen
 
 tools:
 	$(ARCH) mint bootstrap
+
+xc-framework:
+	$(ARCH) mint run swift-create-xcframework --zip --xc-setting SKIP_INSTALL=NO --xc-setting BUILD_LIBRARY_FOR_DISTRIBUTION=YES


### PR DESCRIPTION
- Fixes missing arch error encountered in [recent workflow run](https://github.com/stytchauth/stytch-swift/actions/runs/3841410579/jobs/6541595097) by moving command to Makefile and having ARCH be dynamic
- Completes SDK-740 by using gh cli vs action-gh-release