### PR TITLE
[feat] Add custom email template support

### DIFF
--- a/Sources/StytchCore/Generated/StytchClient.MagicLinks.Email.loginOrCreate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.MagicLinks.Email.loginOrCreate+AsyncVariants.generated.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public extension StytchClient.MagicLinks.Email {
     /// Wraps Stytch's email magic link [login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-email) endpoint. Requests an email magic link for a user to log in or create an account depending on the presence and/or status current account.
-    func loginOrCreate(parameters: LoginOrCreateParameters, completion: @escaping Completion<BasicResponse>) {
+    func loginOrCreate(parameters: Parameters, completion: @escaping Completion<BasicResponse>) {
         Task {
             do {
                 completion(.success(try await loginOrCreate(parameters: parameters)))
@@ -16,7 +16,7 @@ public extension StytchClient.MagicLinks.Email {
     }
 
     /// Wraps Stytch's email magic link [login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-email) endpoint. Requests an email magic link for a user to log in or create an account depending on the presence and/or status current account.
-    func loginOrCreate(parameters: LoginOrCreateParameters) -> AnyPublisher<BasicResponse, Error> {
+    func loginOrCreate(parameters: Parameters) -> AnyPublisher<BasicResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchClient.MagicLinks.Email.send+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.MagicLinks.Email.send+AsyncVariants.generated.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public extension StytchClient.MagicLinks.Email {
     /// Wraps Stytch's email magic link [send](https://stytch.com/docs/api/send-by-email) endpoint. Requests an email magic link for an existing user to log in or attach the included email factor to their current account.
-    func send(parameters: SendParameters, completion: @escaping Completion<BasicResponse>) {
+    func send(parameters: Parameters, completion: @escaping Completion<BasicResponse>) {
         Task {
             do {
                 completion(.success(try await send(parameters: parameters)))
@@ -16,7 +16,7 @@ public extension StytchClient.MagicLinks.Email {
     }
 
     /// Wraps Stytch's email magic link [send](https://stytch.com/docs/api/send-by-email) endpoint. Requests an email magic link for an existing user to log in or attach the included email factor to their current account.
-    func send(parameters: SendParameters) -> AnyPublisher<BasicResponse, Error> {
+    func send(parameters: Parameters) -> AnyPublisher<BasicResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/StytchClient/MagicLinks/Email/Email.swift
+++ b/Sources/StytchCore/StytchClient/MagicLinks/Email/Email.swift
@@ -43,11 +43,13 @@ public extension StytchClient.MagicLinks.Email {
             case email
             case loginMagicLinkUrl
             case loginExpiration = "login_expiration_minutes"
+            case loginTemplateId
         }
 
         let email: String
         let loginMagicLinkUrl: URL?
         let loginExpiration: Minutes?
+        let loginTemplateId: String?
 
         /**
          Initializes the parameters struct
@@ -55,15 +57,18 @@ public extension StytchClient.MagicLinks.Email {
            - email: The email of the user to send the invite magic link to.
            - loginMagicLinkUrl: The url the user clicks from the login email magic link. This should be a url that your app receives and parses and subsequently send an API request to authenticate the magic link and log in the user. If this value is not passed, the default login redirect URL that you set in your Dashboard is used. If you have not set a default login redirect URL, an error is returned.
            - loginExpiration: Set the expiration for the login email magic link, in minutes. By default, it expires in 1 hour. The minimum expiration is 5 minutes and the maximum is 7 days (10080 mins).
+           - loginTemplateId: Use a custom template for login emails. By default, it will use your default email template. The template must be a template using our built-in customizations or a custom HTML email for Magic links - Login.
          */
         public init(
             email: String,
             loginMagicLinkUrl: URL? = nil,
-            loginExpiration: Minutes? = nil
+            loginExpiration: Minutes? = nil,
+            loginTemplateId: String? = nil
         ) {
             self.email = email
             self.loginMagicLinkUrl = loginMagicLinkUrl
             self.loginExpiration = loginExpiration
+            self.loginTemplateId = loginTemplateId
         }
     }
 
@@ -75,13 +80,17 @@ public extension StytchClient.MagicLinks.Email {
             case signupMagicLinkUrl
             case loginExpiration = "login_expiration_minutes"
             case signupExpiration = "signup_expiration_minutes"
+            case loginTemplateId
+            case signupTemplateId
         }
 
         let email: String
         let loginMagicLinkUrl: URL?
         let loginExpiration: Minutes?
+        let loginTemplateId: String?
         let signupMagicLinkUrl: URL?
         let signupExpiration: Minutes?
+        let signupTemplateId: String?
 
         /**
          Initializes the parameters struct
@@ -89,21 +98,27 @@ public extension StytchClient.MagicLinks.Email {
            - email: The email of the user to send the invite magic link to.
            - loginMagicLinkUrl: The url the user clicks from the login email magic link. This should be a url that your app receives and parses and subsequently send an API request to authenticate the magic link and log in the user. If this value is not passed, the default login redirect URL that you set in your Dashboard is used. If you have not set a default login redirect URL, an error is returned.
            - loginExpiration: Set the expiration for the login email magic link, in minutes. By default, it expires in 1 hour. The minimum expiration is 5 minutes and the maximum is 7 days (10080 mins).
+           - loginTemplateId: Use a custom template for login emails. By default, it will use your default email template. The template must be a template using our built-in customizations or a custom HTML email for Magic links - Login.
            - signupMagicLinkUrl: The url the user clicks from the sign-up email magic link. This should be a url that your app receives and parses and subsequently send an api request to authenticate the magic link and sign-up the user. If this value is not passed, the default sign-up redirect URL that you set in your Dashboard is used. If you have not set a default sign-up redirect URL, an error is returned.
            - signupExpiration: Set the expiration for the sign-up email magic link, in minutes. By default, it expires in 1 week. The minimum expiration is 5 minutes and the maximum is 7 days (10080 mins).
+           - signupTemplateId: Use a custom template for sign-up emails. By default, it will use your default email template. The template must be a template using our built-in customizations or a custom HTML email for Magic links - Sign-up.
          */
         public init(
             email: String,
             loginMagicLinkUrl: URL? = nil,
             loginExpiration: Minutes? = nil,
+            loginTemplateId: String? = nil,
             signupMagicLinkUrl: URL? = nil,
-            signupExpiration: Minutes? = nil
+            signupExpiration: Minutes? = nil,
+            signupTemplateId: String? = nil
         ) {
             self.email = email
             self.loginMagicLinkUrl = loginMagicLinkUrl
             self.loginExpiration = loginExpiration
+            self.loginTemplateId = loginTemplateId
             self.signupMagicLinkUrl = signupMagicLinkUrl
             self.signupExpiration = signupExpiration
+            self.signupTemplateId = signupTemplateId
         }
     }
 }

--- a/Sources/StytchCore/StytchClient/MagicLinks/Email/Email.swift
+++ b/Sources/StytchCore/StytchClient/MagicLinks/Email/Email.swift
@@ -7,7 +7,7 @@ public extension StytchClient.MagicLinks {
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's email magic link [login_or_create](https://stytch.com/docs/api/log-in-or-create-user-by-email) endpoint. Requests an email magic link for a user to log in or create an account depending on the presence and/or status current account.
-        public func loginOrCreate(parameters: LoginOrCreateParameters) async throws -> BasicResponse {
+        public func loginOrCreate(parameters: Parameters) async throws -> BasicResponse {
             let (codeChallenge, codeChallengeMethod) = try StytchClient.generateAndStorePKCE(keychainItem: .emlPKCECodeVerifier)
 
             return try await router.post(
@@ -22,7 +22,7 @@ public extension StytchClient.MagicLinks {
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's email magic link [send](https://stytch.com/docs/api/send-by-email) endpoint. Requests an email magic link for an existing user to log in or attach the included email factor to their current account.
-        public func send(parameters: SendParameters) async throws -> BasicResponse {
+        public func send(parameters: Parameters) async throws -> BasicResponse {
             let (codeChallenge, codeChallengeMethod) = try StytchClient.generateAndStorePKCE(keychainItem: .emlPKCECodeVerifier)
 
             return try await router.post(
@@ -37,43 +37,8 @@ public extension StytchClient.MagicLinks {
 }
 
 public extension StytchClient.MagicLinks.Email {
-    /// The dedicated parameters type for email magic link `send` calls.
-    struct SendParameters: Encodable {
-        private enum CodingKeys: String, CodingKey {
-            case email
-            case loginMagicLinkUrl
-            case loginExpiration = "login_expiration_minutes"
-            case loginTemplateId
-        }
-
-        let email: String
-        let loginMagicLinkUrl: URL?
-        let loginExpiration: Minutes?
-        let loginTemplateId: String?
-
-        /**
-         Initializes the parameters struct
-         - Parameters:
-           - email: The email of the user to send the invite magic link to.
-           - loginMagicLinkUrl: The url the user clicks from the login email magic link. This should be a url that your app receives and parses and subsequently send an API request to authenticate the magic link and log in the user. If this value is not passed, the default login redirect URL that you set in your Dashboard is used. If you have not set a default login redirect URL, an error is returned.
-           - loginExpiration: Set the expiration for the login email magic link, in minutes. By default, it expires in 1 hour. The minimum expiration is 5 minutes and the maximum is 7 days (10080 mins).
-           - loginTemplateId: Use a custom template for login emails. By default, it will use your default email template. The template must be a template using our built-in customizations or a custom HTML email for Magic links - Login.
-         */
-        public init(
-            email: String,
-            loginMagicLinkUrl: URL? = nil,
-            loginExpiration: Minutes? = nil,
-            loginTemplateId: String? = nil
-        ) {
-            self.email = email
-            self.loginMagicLinkUrl = loginMagicLinkUrl
-            self.loginExpiration = loginExpiration
-            self.loginTemplateId = loginTemplateId
-        }
-    }
-
-    /// The dedicated parameters type for email magic link `loginOrCreate` calls.
-    struct LoginOrCreateParameters: Encodable {
+    /// The dedicated parameters type for ``StytchClient/MagicLinks-swift.struct/Email-swift.struct/loginOrCreate(parameters:)`` and ``StytchClient/MagicLinks-swift.struct/Email-swift.struct/send(parameters:)`` calls.
+    struct Parameters: Encodable {
         private enum CodingKeys: String, CodingKey {
             case email
             case loginMagicLinkUrl

--- a/Sources/StytchCore/StytchClient/OneTimePasscodes/OneTimePasscodes.swift
+++ b/Sources/StytchCore/StytchClient/OneTimePasscodes/OneTimePasscodes.swift
@@ -55,7 +55,13 @@ public extension StytchClient.OneTimePasscodes {
 public extension StytchClient.OneTimePasscodes {
     /// The dedicated parameters type for OTP `loginOrCreate` and `send` calls.
     struct Parameters: Encodable {
-        private enum CodingKeys: String, CodingKey { case phoneNumber, email, expiration = "expiration_minutes" }
+        private enum CodingKeys: String, CodingKey {
+            case phoneNumber
+            case email
+            case expiration = "expiration_minutes"
+            case loginTemplateId
+            case signupTemplateId
+        }
 
         let deliveryMethod: DeliveryMethod
         let expiration: Minutes?
@@ -74,8 +80,10 @@ public extension StytchClient.OneTimePasscodes {
             switch deliveryMethod {
             case let .sms(value), let .whatsapp(value):
                 try container.encode(value, forKey: .phoneNumber)
-            case let .email(value):
-                try container.encode(value, forKey: .email)
+            case let .email(email, loginTemplateId, signupTemplateId):
+                try container.encode(email, forKey: .email)
+                try container.encodeIfPresent(loginTemplateId, forKey: .loginTemplateId)
+                try container.encodeIfPresent(signupTemplateId, forKey: .signupTemplateId)
             }
         }
     }
@@ -96,8 +104,8 @@ public extension StytchClient.OneTimePasscodes {
         case sms(phoneNumber: String)
         /// The phone number of the user to send a one-time passcode. The phone number should be in E.164 format (i.e. +1XXXXXXXXXX)
         case whatsapp(phoneNumber: String)
-        /// The email address of the user to send the one-time passcode to.
-        case email(String)
+        /// The email address of the user to send the one-time passcode to as well as the custom email template ID values. NOTE: - signupTemplateID will be ignored for ``StytchClient/OneTimePasscodes/send(parameters:)-6f247``
+        case email(email: String, loginTemplateId: String? = nil, signupTemplateId: String? = nil)
 
         var path: Path {
             switch self {

--- a/Sources/StytchCore/StytchClient/OneTimePasscodes/OneTimePasscodes.swift
+++ b/Sources/StytchCore/StytchClient/OneTimePasscodes/OneTimePasscodes.swift
@@ -104,7 +104,7 @@ public extension StytchClient.OneTimePasscodes {
         case sms(phoneNumber: String)
         /// The phone number of the user to send a one-time passcode. The phone number should be in E.164 format (i.e. +1XXXXXXXXXX)
         case whatsapp(phoneNumber: String)
-        /// The email address of the user to send the one-time passcode to as well as the custom email template ID values. NOTE: - signupTemplateID will be ignored for ``StytchClient/OneTimePasscodes/send(parameters:)-6f247``
+        /// The email address of the user to send the one-time passcode to as well as the custom email template ID values.
         case email(email: String, loginTemplateId: String? = nil, signupTemplateId: String? = nil)
 
         var path: Path {

--- a/Sources/StytchCore/StytchClient/Passwords/Passwords.swift
+++ b/Sources/StytchCore/StytchClient/Passwords/Passwords.swift
@@ -124,6 +124,7 @@ public extension StytchClient.Passwords {
             case loginExpiration = "login_expiration_minutes"
             case resetPasswordUrl = "reset_password_redirect_url"
             case resetPasswordExpiration = "reset_password_expiration_minutes"
+            case resetPasswordTemplateId
         }
 
         public let email: String
@@ -131,6 +132,7 @@ public extension StytchClient.Passwords {
         public let loginExpiration: Minutes?
         public let resetPasswordUrl: URL?
         public let resetPasswordExpiration: Minutes?
+        public let resetPasswordTemplateId: String?
 
         /// - Parameters:
         ///   - email: The user's email address.
@@ -138,18 +140,21 @@ public extension StytchClient.Passwords {
         ///   - loginExpiration: Set the expiration for the direct login link, in minutes. By default, it expires in 1 hour. The minimum expiration is 5 minutes and the maximum is 7 days (10080 mins).
         ///   - resetPasswordUrl: The url that the user clicks from the password reset email to finish the reset password flow. This should be a url that your app receives and parses and subsequently send an API request to authenticate the magic link and log in the user. If this value is not passed, the default login redirect URL that you set in your Dashboard is used. If you have not set a default login redirect URL, an error is returned.
         ///   - resetPasswordExpiration: Set the expiration for the password reset, in minutes. By default, it expires in 1 hour. The minimum expiration is 5 minutes and the maximum is 7 days (10080 mins).
+        ///   - resetPasswordTemplateId: Use a custom template for password reset emails. By default, it will use your default email template. The template must be a template using our built-in customizations or a custom HTML email for Passwords - Password reset.
         public init(
             email: String,
             loginUrl: URL? = nil,
             loginExpiration: Minutes? = nil,
             resetPasswordUrl: URL? = nil,
-            resetPasswordExpiration: Minutes? = nil
+            resetPasswordExpiration: Minutes? = nil,
+            resetPasswordTemplateId: String? = nil
         ) {
             self.email = email
             self.loginUrl = loginUrl
             self.loginExpiration = loginExpiration
             self.resetPasswordUrl = resetPasswordUrl
             self.resetPasswordExpiration = resetPasswordExpiration
+            self.resetPasswordTemplateId = resetPasswordTemplateId
         }
     }
 

--- a/StytchDemo/Client/Shared/EmailAuthenticationView.swift
+++ b/StytchDemo/Client/Shared/EmailAuthenticationView.swift
@@ -5,14 +5,16 @@ struct EmailAuthenticationView: View {
     private var serverUrl: URL { configuration.serverUrl }
 
     @State private var email: String = ""
+    @State private var loginTemplateId: String = ""
+    @State private var signupTemplateId: String = ""
     @State private var isLoading = false
     @State private var checkEmailPresented = false
 
-    @Environment(\.openURL) var openUrl
+    @Environment(\.openURL) private var openUrl
 
     var body: some View {
         VStack {
-            TextField(text: $email, label: { Text("Email") })
+            TextField("Email", text: $email)
                 .onSubmit(login)
                 .padding()
                 .textFieldStyle(.roundedBorder)
@@ -21,6 +23,24 @@ struct EmailAuthenticationView: View {
                 .textInputAutocapitalization(.never)
                 .keyboardType(.emailAddress)
                 .textContentType(.emailAddress)
+            #endif
+
+            TextField("Signup template ID", text: $signupTemplateId)
+                .onSubmit(login)
+                .padding()
+                .textFieldStyle(.roundedBorder)
+                .disableAutocorrection(true)
+            #if !os(macOS)
+                .textInputAutocapitalization(.never)
+            #endif
+
+            TextField("Login template ID", text: $loginTemplateId)
+                .onSubmit(login)
+                .padding()
+                .textFieldStyle(.roundedBorder)
+                .disableAutocorrection(true)
+            #if !os(macOS)
+                .textInputAutocapitalization(.never)
             #endif
 
             Button(action: login, label: {
@@ -51,7 +71,13 @@ struct EmailAuthenticationView: View {
         Task {
             do {
                 _ = try await StytchClient.magicLinks.email.loginOrCreate(
-                    parameters: .init(email: email, loginMagicLinkUrl: serverUrl, signupMagicLinkUrl: serverUrl)
+                    parameters: .init(
+                        email: email,
+                        loginMagicLinkUrl: serverUrl,
+                        loginTemplateId: loginTemplateId.presence,
+                        signupMagicLinkUrl: serverUrl,
+                        signupTemplateId: signupTemplateId.presence
+                    )
                 )
                 checkEmailPresented = true
             } catch {

--- a/StytchDemo/Client/Shared/HobbiesView.swift
+++ b/StytchDemo/Client/Shared/HobbiesView.swift
@@ -84,8 +84,8 @@ struct HobbyList: Codable {
 
 extension HobbiesView {
     final class Model: ObservableObject {
-        @Published var hobbies: [Hobby] = []
-        @Published var onAuthError: Void?
+        @Published private(set) var hobbies: [Hobby] = []
+        @Published private(set) var onAuthError: Void?
 
         func fetch() {
             Task {

--- a/StytchDemo/Client/Shared/Passwords/PasswordAuthenticationView.swift
+++ b/StytchDemo/Client/Shared/Passwords/PasswordAuthenticationView.swift
@@ -31,7 +31,7 @@ struct PasswordAuthenticationView: View {
             Toggle("Hide Password", isOn: $model.isSecure)
                 .padding(.horizontal)
 
-            TextField(text: $model.email, label: { Text("Email") })
+            TextField("Email", text: $model.email)
                 .padding()
                 .textFieldStyle(.roundedBorder)
                 .disableAutocorrection(true)
@@ -49,6 +49,14 @@ struct PasswordAuthenticationView: View {
                 password: $model.password,
                 publisher: model.$password
             )
+
+            TextField("Reset template ID", text: $model.resetTemplateId)
+                .padding()
+                .textFieldStyle(.roundedBorder)
+                .disableAutocorrection(true)
+            #if !os(macOS)
+                .textInputAutocapitalization(.never)
+            #endif
 
             if authOption == .signUp {
                 PasswordFeedbackView(strength: model.strength, warning: model.warning, feedback: model.feedback)

--- a/StytchDemo/Client/Shared/Passwords/PasswordModel.swift
+++ b/StytchDemo/Client/Shared/Passwords/PasswordModel.swift
@@ -9,6 +9,7 @@ final class PasswordModel: ObservableObject {
     @Published var warning = ""
     @Published var feedback = ""
     @Published var isValid = false
+    @Published var resetTemplateId: String = ""
 
     func checkStrength() {
         Task {
@@ -31,7 +32,12 @@ final class PasswordModel: ObservableObject {
     @discardableResult
     func resetPasswordStart() async throws -> BasicResponse {
         try await StytchClient.passwords.resetByEmailStart(
-            parameters: .init(email: email, loginUrl: configuration.serverUrl, resetPasswordUrl: configuration.serverUrl)
+            parameters: .init(
+                email: email,
+                loginUrl: configuration.serverUrl,
+                resetPasswordUrl: configuration.serverUrl,
+                resetPasswordTemplateId: resetTemplateId.presence
+            )
         )
     }
 

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -37,7 +37,7 @@ final class MagicLinksTestCase: BaseTestCase {
                 "login_magic_link_url": "https://myapp.com/login",
                 "login_expiration_minutes": 30,
                 "login_template_id": "g'day",
-                "signup_template_id": "mate"
+                "signup_template_id": "mate",
             ])
         )
     }
@@ -70,7 +70,7 @@ final class MagicLinksTestCase: BaseTestCase {
                 "email": "asdf@stytch.com",
                 "login_magic_link_url": "https://myapp.com/login",
                 "login_expiration_minutes": 30,
-                "login_template_id": "hello"
+                "login_template_id": "hello",
             ])
         )
     }

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -7,7 +7,7 @@ final class MagicLinksTestCase: BaseTestCase {
             BasicResponse(requestId: "1234", statusCode: 200)
         }
         let baseUrl = try XCTUnwrap(URL(string: "https://myapp.com"))
-        let parameters: StytchClient.MagicLinks.Email.LoginOrCreateParameters = .init(
+        let parameters: StytchClient.MagicLinks.Email.Parameters = .init(
             email: "asdf@stytch.com",
             loginMagicLinkUrl: baseUrl.appendingPathComponent("login"),
             loginExpiration: 30,
@@ -45,7 +45,7 @@ final class MagicLinksTestCase: BaseTestCase {
     func testMagicLinksSendWithNoSession() async throws {
         networkInterceptor.responses { BasicResponse(requestId: "1234", statusCode: 200) }
         let baseUrl = try XCTUnwrap(URL(string: "https://myapp.com"))
-        let parameters: StytchClient.MagicLinks.Email.SendParameters = .init(
+        let parameters: StytchClient.MagicLinks.Email.Parameters = .init(
             email: "asdf@stytch.com",
             loginMagicLinkUrl: baseUrl.appendingPathComponent("login"),
             loginExpiration: 30,
@@ -78,7 +78,7 @@ final class MagicLinksTestCase: BaseTestCase {
     func testMagicLinksSendWithActiveSession() async throws {
         networkInterceptor.responses { BasicResponse(requestId: "1234", statusCode: 200) }
         let baseUrl = try XCTUnwrap(URL(string: "https://myapp.com"))
-        let parameters: StytchClient.MagicLinks.Email.SendParameters = .init(
+        let parameters: StytchClient.MagicLinks.Email.Parameters = .init(
             email: "asdf@stytch.com",
             loginMagicLinkUrl: baseUrl.appendingPathComponent("login"),
             loginExpiration: 30

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -11,8 +11,10 @@ final class MagicLinksTestCase: BaseTestCase {
             email: "asdf@stytch.com",
             loginMagicLinkUrl: baseUrl.appendingPathComponent("login"),
             loginExpiration: 30,
+            loginTemplateId: "g'day",
             signupMagicLinkUrl: baseUrl.appendingPathComponent("signup"),
-            signupExpiration: 30
+            signupExpiration: 30,
+            signupTemplateId: "mate"
         )
 
         XCTAssertTrue(try Current.keychainClient.get(.emlPKCECodeVerifier).isEmpty)
@@ -34,6 +36,8 @@ final class MagicLinksTestCase: BaseTestCase {
                 "email": "asdf@stytch.com",
                 "login_magic_link_url": "https://myapp.com/login",
                 "login_expiration_minutes": 30,
+                "login_template_id": "g'day",
+                "signup_template_id": "mate"
             ])
         )
     }
@@ -44,7 +48,8 @@ final class MagicLinksTestCase: BaseTestCase {
         let parameters: StytchClient.MagicLinks.Email.SendParameters = .init(
             email: "asdf@stytch.com",
             loginMagicLinkUrl: baseUrl.appendingPathComponent("login"),
-            loginExpiration: 30
+            loginExpiration: 30,
+            loginTemplateId: "hello"
         )
 
         XCTAssertFalse(Current.sessionStorage.activeSessionExists)
@@ -65,6 +70,7 @@ final class MagicLinksTestCase: BaseTestCase {
                 "email": "asdf@stytch.com",
                 "login_magic_link_url": "https://myapp.com/login",
                 "login_expiration_minutes": 30,
+                "login_template_id": "hello"
             ])
         )
     }

--- a/Tests/StytchCoreTests/NetworkingClientInterceptor.swift
+++ b/Tests/StytchCoreTests/NetworkingClientInterceptor.swift
@@ -144,3 +144,9 @@ enum SuccessResponsesBuilder {
 struct ResponsesContainer {
     let responses: [Result<any Codable, Error>]
 }
+
+struct ExpectedRequest<T> {
+    let parameters: T
+    let urlString: String
+    let body: JSON
+}

--- a/Tests/StytchCoreTests/OneTimePasscodesTestCase.swift
+++ b/Tests/StytchCoreTests/OneTimePasscodesTestCase.swift
@@ -2,12 +2,16 @@ import XCTest
 @testable import StytchCore
 
 final class OneTimePasscodesTestCase: BaseTestCase {
+    private typealias Base = StytchClient.OneTimePasscodes
+    private typealias ExpectedValues = ExpectedRequest<Base.Parameters>
+
+    private let response: Base.OTPResponse = .init(
+        requestId: "1234",
+        statusCode: 200,
+        wrapped: .init(methodId: "method_id_1234")
+    )
+
     func testOtpLoginOrCreate() async throws {
-        let response: StytchClient.OneTimePasscodes.OTPResponse = .init(
-            requestId: "1234",
-            statusCode: 200,
-            wrapped: .init(methodId: "method_id_1234")
-        )
         networkInterceptor.responses {
             response
             response
@@ -43,11 +47,6 @@ final class OneTimePasscodesTestCase: BaseTestCase {
     }
 
     func testOtpSendWithNoSession() async throws {
-        let response: StytchClient.OneTimePasscodes.OTPResponse = .init(
-            requestId: "1234",
-            statusCode: 200,
-            wrapped: .init(methodId: "method_id_1234")
-        )
         networkInterceptor.responses {
             response
             response
@@ -91,11 +90,6 @@ final class OneTimePasscodesTestCase: BaseTestCase {
     }
 
     func testOtpSendWithActiveSession() async throws {
-        let response: StytchClient.OneTimePasscodes.OTPResponse = .init(
-            requestId: "1234",
-            statusCode: 200,
-            wrapped: .init(methodId: "method_id_1234")
-        )
         networkInterceptor.responses {
             response
             response
@@ -132,7 +126,7 @@ final class OneTimePasscodesTestCase: BaseTestCase {
 
     func testOtpAuthenticate() async throws {
         networkInterceptor.responses { AuthenticateResponse.mock }
-        let parameters: StytchClient.OneTimePasscodes.AuthenticateParameters = .init(
+        let parameters: Base.AuthenticateParameters = .init(
             code: "i_am_code",
             methodId: "method_id_fake_id",
             sessionDuration: 20
@@ -157,13 +151,5 @@ final class OneTimePasscodesTestCase: BaseTestCase {
                 "session_duration_minutes": 20,
             ])
         )
-    }
-}
-
-private extension OneTimePasscodesTestCase {
-    struct ExpectedValues {
-        let parameters: StytchClient.OneTimePasscodes.Parameters
-        let urlString: String
-        let body: JSON
     }
 }

--- a/Tests/StytchCoreTests/OneTimePasscodesTestCase.swift
+++ b/Tests/StytchCoreTests/OneTimePasscodesTestCase.swift
@@ -16,7 +16,7 @@ final class OneTimePasscodesTestCase: BaseTestCase {
 
         try await [
             ExpectedValues(
-                parameters: StytchClient.OneTimePasscodes.Parameters(deliveryMethod: .whatsapp(phoneNumber: "+12345678901"), expiration: 3),
+                parameters: .init(deliveryMethod: .whatsapp(phoneNumber: "+12345678901"), expiration: 3),
                 urlString: "https://web.stytch.com/sdk/v1/otps/whatsapp/login_or_create",
                 body: ["expiration_minutes": 3, "phone_number": "+12345678901"]
             ),
@@ -26,7 +26,7 @@ final class OneTimePasscodesTestCase: BaseTestCase {
                 body: ["phone_number": "+11098765432"]
             ),
             .init(
-                parameters: .init(deliveryMethod: .email("test@stytch.com")),
+                parameters: .init(deliveryMethod: .email(email: "test@stytch.com")),
                 urlString: "https://web.stytch.com/sdk/v1/otps/email/login_or_create",
                 body: ["email": "test@stytch.com"]
             ),
@@ -52,6 +52,7 @@ final class OneTimePasscodesTestCase: BaseTestCase {
             response
             response
             response
+            response
         }
 
         XCTAssertFalse(Current.sessionStorage.activeSessionExists)
@@ -68,7 +69,12 @@ final class OneTimePasscodesTestCase: BaseTestCase {
                 body: ["phone_number": "+11098765432"]
             ),
             .init(
-                parameters: .init(deliveryMethod: .email("test@stytch.com")),
+                parameters: .init(deliveryMethod: .email(email: "test@stytch.com", loginTemplateId: "fake-id", signupTemplateId: "blah")),
+                urlString: "https://web.stytch.com/sdk/v1/otps/email/send/primary",
+                body: ["email": "test@stytch.com", "login_template_id": "fake-id", "signup_template_id": "blah"]
+            ),
+            .init(
+                parameters: .init(deliveryMethod: .email(email: "test@stytch.com")),
                 urlString: "https://web.stytch.com/sdk/v1/otps/email/send/primary",
                 body: ["email": "test@stytch.com"]
             ),
@@ -112,7 +118,7 @@ final class OneTimePasscodesTestCase: BaseTestCase {
                 body: ["phone_number": "+11098765432"]
             ),
             .init(
-                parameters: .init(deliveryMethod: .email("test@stytch.com")),
+                parameters: .init(deliveryMethod: .email(email: "test@stytch.com")),
                 urlString: "https://web.stytch.com/sdk/v1/otps/email/send/secondary",
                 body: ["email": "test@stytch.com"]
             ),

--- a/Tests/StytchCoreTests/PasskeysTestCase.swift
+++ b/Tests/StytchCoreTests/PasskeysTestCase.swift
@@ -5,8 +5,10 @@ import XCTest
 #if !os(watchOS)
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 final class PasskeysTestCase: BaseTestCase {
+    private typealias Base = StytchClient.Passkeys
+
     func testRegister() async throws {
-        let startResponse: StytchClient.Passkeys.RegisterStartResponseData = .init(
+        let startResponse: Base.RegisterStartResponseData = .init(
             userId: "user_id_123",
             challenge: try Current.cryptoClient.dataWithRandomBytesOfCount(32)
         )
@@ -39,7 +41,7 @@ final class PasskeysTestCase: BaseTestCase {
     }
 
     func testAuthenticate() async throws {
-        let startResponse: StytchClient.Passkeys.AuthenticateStartResponseData = .init(
+        let startResponse: Base.AuthenticateStartResponseData = .init(
             userId: "user_id_123",
             challenge: try Current.cryptoClient.dataWithRandomBytesOfCount(32)
         )
@@ -64,9 +66,9 @@ final class PasskeysTestCase: BaseTestCase {
         }
         Current.timer = { _, _, _ in .init() }
         #if os(iOS)
-        let parameters: StytchClient.Passkeys.AuthenticateParameters = .init(domain: "something.blah.com", requestBehavior: .autoFill)
+        let parameters: Base.AuthenticateParameters = .init(domain: "something.blah.com", requestBehavior: .autoFill)
         #else
-        let parameters: StytchClient.Passkeys.AuthenticateParameters = .init(domain: "something.blah.com")
+        let parameters: Base.AuthenticateParameters = .init(domain: "something.blah.com")
         #endif
         _ = try await StytchClient.passkeys.authenticate(parameters: parameters)
         #if os(iOS)
@@ -154,6 +156,5 @@ final class MockRegistration: NSObject, ASAuthorizationPublicKeyCredentialRegist
 
     func encode(with _: NSCoder) {}
 }
-
 // swiftlint:enable unavailable_function
 #endif

--- a/Tests/StytchCoreTests/PasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/PasswordsTestCase.swift
@@ -61,7 +61,9 @@ final class PasswordsTestCase: BaseTestCase {
             BasicResponse(requestId: "123", statusCode: 200)
             AuthenticateResponse.mock
         }
-        _ = try await StytchClient.passwords.resetByEmailStart(parameters: .init(email: "user@stytch.com", loginUrl: nil, loginExpiration: nil, resetPasswordUrl: XCTUnwrap(URL(string: "https://stytch.com/reset")), resetPasswordExpiration: 15))
+        _ = try await StytchClient.passwords.resetByEmailStart(
+            parameters: .init(email: "user@stytch.com", loginUrl: nil, loginExpiration: nil, resetPasswordUrl: XCTUnwrap(URL(string: "https://stytch.com/reset")), resetPasswordExpiration: 15, resetPasswordTemplateId: "one-two-buckle-my-shoe")
+        )
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -72,6 +74,7 @@ final class PasswordsTestCase: BaseTestCase {
                 "reset_password_redirect_url": "https://stytch.com/reset",
                 "code_challenge": "V9dLhNVhiUv_9m8cwFSzLGR9l-q6NAeLskiVZ7WsjA8",
                 "code_challenge_method": "S256",
+                "reset_password_template_id": "one-two-buckle-my-shoe"
             ])
         )
 

--- a/Tests/StytchCoreTests/PasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/PasswordsTestCase.swift
@@ -74,7 +74,7 @@ final class PasswordsTestCase: BaseTestCase {
                 "reset_password_redirect_url": "https://stytch.com/reset",
                 "code_challenge": "V9dLhNVhiUv_9m8cwFSzLGR9l-q6NAeLskiVZ7WsjA8",
                 "code_challenge_method": "S256",
-                "reset_password_template_id": "one-two-buckle-my-shoe"
+                "reset_password_template_id": "one-two-buckle-my-shoe",
             ])
         )
 


### PR DESCRIPTION
* Adding in template id values to params
* Consolidation of param types where possible
* Some test cleanup
* Adding the ability to adjust template ids in the demo app

Completes SDK-788