### PR TITLE
feat: Add support for versioned docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Generate docs
       run: |
         mkdir -p docs/live/${{ matrix.ref-label }}
-        if [[ $(find docs/live/${{ matrix.ref-label }} -type d -empty) ]]; then
+        if [[ $(find docs/live/${{ matrix.ref-label }} -type d -empty) || ${{ matrix.ref-label }} == 'main' || ${{ matrix.ref-label }} == 'latest' ]]; then
           make codegen
           REF=${{ matrix.ref-label }} make docs-site
         fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,19 +25,26 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/checkout@v3
+        with:
+          ref: docs/live
+          path: docs-live
+
       - id: set-matrix
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           matrix_values='{"ref":"main","ref-label":"main"}'
+          latest_ref=$(git describe --tags --abbrev=0)
+          matrix_values+=",{\"ref\":\"$latest_ref\",\"ref-label\":\"latest\"}"
 
           for ref in $(git tag --list); do
-            matrix_values+=",{\"ref\":\"$ref\",\"ref-label\":\"$ref\"}"
+            docs_path="docs/live/$ref"
+            mkdir -p $docs_path
+            if [[ $(find $docs_path -type d -empty) ]]; then
+              matrix_values+=",{\"ref\":\"$ref\",\"ref-label\":\"$ref\"}"
+            fi
           done
-
-          latest_ref=$(git describe --tags --abbrev=0)
-
-          matrix_values+=",{\"ref\":\"$latest_ref\",\"ref-label\":\"latest\"}"
 
           echo "matrix-values=[${matrix_values}]" >> $GITHUB_OUTPUT
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
@@ -55,21 +62,11 @@ jobs:
       with:
         ref: ${{ matrix.ref }}
 
-    - uses: actions/checkout@v3
-      with:
-        ref: docs/live
-        path: docs-live
-
     - name: Bootstrap
       uses: ./.github/actions/bootstrap
 
     - name: Generate docs
-      run: |
-        mkdir -p docs/live/${{ matrix.ref-label }}
-        if [[ $(find docs/live/${{ matrix.ref-label }} -type d -empty) || ${{ matrix.ref-label }} == 'main' || ${{ matrix.ref-label }} == 'latest' ]]; then
-          make codegen
-          REF=${{ matrix.ref-label }} make docs-site
-        fi
+      run: REF=${{ matrix.ref-label }} make docs-site
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,11 +29,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          matrix_values='{"ref":"main"}'
+          matrix_values='{"ref":"main","ref-label":"main"}'
 
           for ref in $(git tag --list); do
-            matrix_values+=",{\"ref\": \"$ref\"}"
+            matrix_values+=",{\"ref\":\"$ref\",\"ref-label\":\"$ref\"}"
           done
+
+          latest_ref=$(git describe --tags --abbrev=0)
+
+          matrix_values+=",{\"ref\":\"$latest_ref\",\"ref-label\":\"latest\"}"
 
           echo "matrix-values=[${matrix_values}]" >> $GITHUB_OUTPUT
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
@@ -61,15 +65,15 @@ jobs:
 
     - name: Generate docs
       run: |
-        mkdir -p docs/live/${{ matrix.ref }}
-        if [[ $(find docs/live/${{ matrix.ref }} -type d -empty) ]]; then
+        mkdir -p docs/live/${{ matrix.ref-label }}
+        if [[ $(find docs/live/${{ matrix.ref-label }} -type d -empty) ]]; then
           make codegen
-          REF=${{ matrix.ref }} make docs-site
+          REF=${{ matrix.ref-label }} make docs-site
         fi
 
     - uses: actions/upload-artifact@v3
       with:
-        name: ${{ matrix.ref }}
+        name: ${{ matrix.ref-label }}
         path: .build/docs
 
   publish-docs:
@@ -89,7 +93,7 @@ jobs:
 
     - name: Publish docs
       run: |
-        for ref in $(echo "${{ toJSON(needs.set-matrix.outputs.matrix-values) }}" | jq -r '.[].ref'); do
+        for ref in $(echo "${{ toJSON(needs.set-matrix.outputs.matrix-values) }}" | jq -r '.[].ref-label'); do
           rsync -a "artifacts/$ref" docs-live/docs
         done
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,11 @@
 name: Docs
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
@@ -12,30 +15,85 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull') }}
 
 jobs:
-  docs:
+  set-matrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix-values: ${{ steps.set-matrix.outputs.matrix-values }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: set-matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          matrix_values='{"ref":"main"}'
+
+          for ref in $(git tag --list); do
+            matrix_values+=",{\"ref\": \"$ref\"}"
+          done
+
+          echo "matrix-values=[${matrix_values}]" >> $GITHUB_OUTPUT
+          echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
+
+  generate-docs:
     runs-on: macos-12
+
+    needs: set-matrix
+
+    strategy:
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
 
     steps:
     - uses: actions/checkout@v3
-
-    - name: Bootstrap
-      uses: ./.github/actions/bootstrap
+      with:
+        ref: ${{ matrix.ref }}
 
     - uses: actions/checkout@v3
       with:
         ref: docs/live
         path: docs-live
 
-    - name: Codegen
-      run: make codegen
+    - name: Bootstrap
+      uses: ./.github/actions/bootstrap
 
     - name: Generate docs
-      run: make docs-site
+      run: |
+        mkdir -p docs/live/${{ matrix.ref }}
+        if [[ $(find docs/live/${{ matrix.ref }} -type d -empty) ]]; then
+          make codegen
+          REF=${{ matrix.ref }} make docs-site
+        fi
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.ref }}
+        path: .build/docs
+
+  publish-docs:
+    runs-on: ubuntu-latest
+
+    needs: [set-matrix, generate-docs]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: docs/live
+        path: docs-live
+
+    - uses: actions/download-artifact@v3
+      with:
+        path: artifacts
 
     - name: Publish docs
       run: |
+        for ref in $(echo "${{ toJSON(needs.set-matrix.outputs.matrix-values) }}" | jq -r '.[].ref'); do
+          rsync -a "artifacts/$ref" docs-live/docs
+        done
+
         current_sha="$(git rev-parse @)"
-        rsync -a .build/docs docs-live/
         cd docs-live
         git add docs
         git commit --author="CI <ci@stytch.com>" -m "$current_sha"

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ demo:
 	bundle exec --gemfile=StytchDemo/Gemfile Scripts/demo start
 
 docs: codegen
-	$(ARCH) xcodebuild docbuild -scheme StytchCore -configuration Release -sdk iphoneos$(IOS_VERSION) -destination generic/platform=iOS -derivedDataPath .build | $(XCPRETTY)
+	$(ARCH) xcodebuild clean docbuild -scheme StytchCore -configuration Release -sdk iphoneos$(IOS_VERSION) -destination generic/platform=iOS -derivedDataPath .build | $(XCPRETTY)
 
 docs-site: docs
 	$(ARCH) $$(xcrun --find docc) process-archive transform-for-static-hosting .build/Build/Products/Release-iphoneos/StytchCore.doccarchive --output-path .build/docs --hosting-base-path $(HOSTING_BASE_PATH)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ ARCH=arch -$(shell [ $(IS_CI) ] && echo "x86_64" || echo "arm64")
 PIPEFAIL=set -o pipefail
 XCPRETTY=bundle exec xcpretty
 TEST=$(PIPEFAIL) && $(ARCH) xcodebuild test -disableAutomaticPackageResolution -skipPackageUpdates -project StytchDemo/StytchDemo.xcodeproj -scheme StytchCoreTests -sdk
+HOSTING_BASE_PATH=$(shell echo stytch-swift/$$REF | sed 's:/$$::')
 
 .PHONY: coverage codegen docs format lint setup test tests test-ios test-macos test-tvos test-watchos tools
 
@@ -25,7 +26,7 @@ docs: codegen
 	$(ARCH) xcodebuild docbuild -scheme StytchCore -configuration Release -sdk iphoneos$(IOS_VERSION) -destination generic/platform=iOS -derivedDataPath .build | $(XCPRETTY)
 
 docs-site: docs
-	$(ARCH) $$(xcrun --find docc) process-archive transform-for-static-hosting .build/Build/Products/Release-iphoneos/StytchCore.doccarchive --output-path .build/docs --hosting-base-path stytch-swift
+	$(ARCH) $$(xcrun --find docc) process-archive transform-for-static-hosting .build/Build/Products/Release-iphoneos/StytchCore.doccarchive --output-path .build/docs --hosting-base-path $(HOSTING_BASE_PATH)
 
 format:
 	$(ARCH) mint run swiftformat .

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ final class SMSAuthenticationController {
 
 ## Documentation
 
-Full reference documentation is available [here](https://stytchauth.github.io/stytch-swift/documentation/stytchcore/).
+Full reference documentation is available [here](https://stytchauth.github.io/stytch-swift/latest/documentation/stytchcore/).
 
 ## FAQ
 


### PR DESCRIPTION
## Overview
As part of the current docs overhaul, this PR adds support so that documentation is generated for each tagged version, as well as for the main branch and for the latest tag, so the docs for a given version will be available at `https://stytchauth.github.io/stytch-swift/<ref>/documentation/stytchcore/` with ref being any of the tag values as well as `main` or `latest`. I've gone ahead and manually pushed up docs for each of these so we could be sure it would work properly, several examples of which you can see at:
- https://stytchauth.github.io/stytch-swift/latest/documentation/stytchcore/
- https://stytchauth.github.io/stytch-swift/main/documentation/stytchcore/
- https://stytchauth.github.io/stytch-swift/0.1.0/documentation/stytchcore/
- https://stytchauth.github.io/stytch-swift/0.8.0/documentation/stytchcore/

## Implementation description
Before generating docs, the docs workflow now has a matrix job to create a matrix for `main`, `latest` and for each of the tags which don't already have documentation generated. After the matrix is created, the matrix is then used in a second job to generate the docs and upload artifacts. These artifacts will be subsequently downloaded in the final job where the artifacts are copied to the `docs/live` branch under `docs/<ref>` directories, resulting in per-version documentation being published like at the urls above.

Completes: SDK-869