### PR TITLE
[improvement] Reset Keychain on fresh app install

### DIFF
--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -99,6 +99,8 @@ struct Environment {
 
     var date: () -> Date = Date.init
 
+    var uuid: () -> UUID = UUID.init
+
     var asyncAfter: (DispatchQueue, DispatchTime, @escaping () -> Void) -> Void = { $0.asyncAfter(deadline: $1, execute: $2) }
 
     var timer: (TimeInterval, RunLoop, @escaping () -> Void) -> Timer = { interval, runloop, task in

--- a/Sources/StytchCore/KeychainClient/KeychainClient+Item.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient+Item.swift
@@ -64,6 +64,20 @@ extension KeychainClient.Item {
 }
 
 extension KeychainClient.Item {
+    // TODO: - set up linting or codegen to ensure any new `KeychainClient.Item` added (this file or elsewhere) is added to this array
+    static var allItems: [Self] {
+        [
+            .privateKeyRegistration,
+            .sessionToken,
+            .sessionJwt,
+            .emlPKCECodeVerifier,
+            .pwResetByEmailPKCECodeVerifier,
+            .oauthPKCECodeVerifier,
+        ]
+    }
+}
+
+extension KeychainClient.Item {
     struct Value {
         let data: Data
         let account: String?

--- a/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
@@ -73,12 +73,9 @@ extension StytchClientType {
     }
 
     mutating func postInit() {
-        guard
-            let url = Bundle.main.url(forResource: "StytchConfiguration", withExtension: "plist"),
-            let data = try? Data(contentsOf: url)
-        else { return }
-
-        configuration = try? PropertyListDecoder().decode(Configuration.self, from: data)
+        if let url = Bundle.main.url(forResource: "StytchConfiguration", withExtension: "plist"), let data = try? Data(contentsOf: url) {
+            configuration = try? PropertyListDecoder().decode(Configuration.self, from: data)
+        }
 
         updateHeaderProvider()
         resetKeychainOnFreshInstall()
@@ -109,7 +106,7 @@ extension StytchClientType {
             defaults.string(forKey: installIdDefaultsKey) == nil
         else { return }
 
-        defaults.set(uuid(), forKey: installIdDefaultsKey)
+        defaults.set(uuid().uuidString, forKey: installIdDefaultsKey)
         KeychainClient.Item.allItems.forEach { item in
             try? keychainClient.removeItem(item)
         }

--- a/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
@@ -25,6 +25,8 @@ extension StytchClientType {
 
     private var localStorage: LocalStorage { Current.localStorage }
 
+    private var keychainClient: KeychainClient { Current.keychainClient }
+
     private var networkingClient: NetworkingClient { Current.networkingClient }
 
     private var defaults: UserDefaults { Current.defaults }
@@ -32,6 +34,8 @@ extension StytchClientType {
     private var jsonEncoder: JSONEncoder { Current.jsonEncoder }
 
     private var clientInfo: ClientInfo { Current.clientInfo }
+
+    private var uuid: () -> UUID { Current.uuid }
 
     // swiftlint:disable:next identifier_name
     static func _configure(publicToken: String, hostUrl: URL? = nil) {
@@ -77,6 +81,7 @@ extension StytchClientType {
         configuration = try? PropertyListDecoder().decode(Configuration.self, from: data)
 
         updateHeaderProvider()
+        resetKeychainOnFreshInstall()
         runKeychainMigrations()
     }
 
@@ -95,6 +100,18 @@ extension StytchClientType {
                 "Authorization": "Basic \(authToken)",
                 "X-SDK-Client": clientInfoString ?? "",
             ]
+        }
+    }
+
+    private func resetKeychainOnFreshInstall() {
+        guard
+            case let installIdDefaultsKey = "stytch_install_id_defaults_key",
+            defaults.string(forKey: installIdDefaultsKey) == nil
+        else { return }
+
+        defaults.set(uuid(), forKey: installIdDefaultsKey)
+        KeychainClient.Item.allItems.forEach { item in
+            try? keychainClient.removeItem(item)
         }
     }
 

--- a/Tests/StytchCoreTests/KeychainClientTestCase.swift
+++ b/Tests/StytchCoreTests/KeychainClientTestCase.swift
@@ -58,4 +58,18 @@ final class KeychainClientTestCase: BaseTestCase {
         XCTAssertNil(results.first?.account)
         XCTAssertEqual(results.first?.label, "user@example.com")
     }
+
+    func testKeychainReset() throws {
+        let installIdKey = "stytch_install_id_defaults_key"
+        Current.defaults.set(Current.uuid().uuidString, forKey: installIdKey)
+        try Current.keychainClient.set("token", for: .sessionToken)
+        try Current.keychainClient.set("token_jwt", for: .sessionJwt)
+        StytchClient.instance.postInit()
+        XCTAssertEqual(try Current.keychainClient.get(.sessionToken), "token")
+        XCTAssertEqual(try Current.keychainClient.get(.sessionJwt), "token_jwt")
+        Current.defaults.removeObject(forKey: installIdKey)
+        StytchClient.instance.postInit()
+        XCTAssertNil(try Current.keychainClient.get(.sessionToken))
+        XCTAssertNil(try Current.keychainClient.get(.sessionJwt))
+    }
 }


### PR DESCRIPTION
Due to default iOS behavior of persisting Keychain items/data when an app is uninstalled, our SDK will maintain session data even after an app is uninstalled/reinstalled. This is generally undesirable, and potentially a security concern, so we will start resetting the Keychain when we determine an app is freshly installed. We will do this by leveraging UserDefaults, which do get cleared between installs where we will store a Stytch Install ID. When this value is nil, we know we should clear the keychain