### PR TITLE
[feat] Add ability to tell if user new/returning for SIWA

### DIFF
--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
@@ -35,6 +35,23 @@ public extension StytchClient.OAuth {
 }
 
 public extension StytchClient.OAuth.Apple {
+    /// The concrete response type for Sign In With Apple `authenticate` calls.
+    typealias AuthenticateResponse = Response<AuthenticateResponseData>
+
+    /// The underlying data for Sign In With Apple `authenticate` calls.
+    struct AuthenticateResponseData: Codable, AuthenticateResponseDataType {
+        /// The current user object.
+        public let user: User
+        /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.
+        public let sessionToken: String
+        /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
+        public let sessionJwt: String
+        /// The ``Session`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
+        public let session: Session
+        /// Indicates if this is a new or returning user
+        public let userCreated: Bool
+    }
+
     /// The dedicated parameters type for ``StytchClient/OAuth-swift.struct/Apple-swift.struct/start(parameters:)-7rkef`` calls.
     struct StartParameters {
         let sessionDuration: Minutes
@@ -60,23 +77,6 @@ public extension StytchClient.OAuth.Apple {
             self.sessionDuration = sessionDuration
         }
         #endif
-    }
-
-    /// The concrete response type for Sign In With Apple `authenticate` calls.
-    typealias AuthenticateResponse = Response<AuthenticateResponseData>
-
-    /// The underlying data for Sign In With Apple `authenticate` calls.
-    struct AuthenticateResponseData: Codable, AuthenticateResponseDataType {
-        /// The current user object.
-        public let user: User
-        /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.
-        public let sessionToken: String
-        /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
-        public let sessionJwt: String
-        /// The ``Session`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
-        public let session: Session
-        /// Indicates if this is a new or returning user
-        public let userCreated: Bool
     }
 }
 

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
@@ -61,6 +61,23 @@ public extension StytchClient.OAuth.Apple {
         }
         #endif
     }
+
+    /// The concrete response type for Sign In With Apple `authenticate` calls.
+    typealias AuthenticateResponse = Response<AuthenticateResponseData>
+
+    /// The underlying data for Sign In With Apple `authenticate` calls.
+    struct AuthenticateResponseData: Codable, AuthenticateResponseDataType {
+        /// The current user object.
+        public let user: User
+        /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.
+        public let sessionToken: String
+        /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
+        public let sessionJwt: String
+        /// The ``Session`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
+        public let session: Session
+        /// Indicates if this is a new or returning user
+        public let userCreated: Bool
+    }
 }
 
 extension StytchClient.OAuth.Apple {

--- a/StytchDemo/Client/Shared/OAuthAuthenticationView.swift
+++ b/StytchDemo/Client/Shared/OAuthAuthenticationView.swift
@@ -12,7 +12,9 @@ struct OAuthAuthenticationView: View {
         Button("Authenticate with Apple") {
             Task {
                 do {
-                    onAuth(try await StytchClient.oauth.apple.start(parameters: .init()))
+                    let response = try await StytchClient.oauth.apple.start(parameters: .init())
+                    print("User created: ", response.userCreated)
+                    onAuth(response)
                     presentationMode.wrappedValue.dismiss()
                 } catch {
                     print(error)

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -3,7 +3,13 @@ import XCTest
 
 final class OAuthTestCase: BaseTestCase {
     func testApple() async throws {
-        networkInterceptor.responses { AuthenticateResponse.mock }
+        networkInterceptor.responses {
+            StytchClient.OAuth.Apple.AuthenticateResponse(
+                requestId: "",
+                statusCode: 200,
+                wrapped: .init(user: .mock(userId: ""), sessionToken: "", sessionJwt: "", session: .mock(userId: ""), userCreated: false)
+            )
+        }
         Current.appleOAuthClient = .init { _, _ in .init(idToken: "id_token_123", name: .init(firstName: "user", lastName: nil)) }
         Current.timer = { _, _, _ in .init() }
         _ = try await StytchClient.oauth.apple.start(parameters: .init())


### PR DESCRIPTION
Consumes a new user_created field from web-backend, which informs the client whether Sign In With Apple auth is for a new or returning user

Completes client work for SDK-870